### PR TITLE
fix: complete Copilot turns after usage arrives

### DIFF
--- a/apps/server/src/provider/Layers/CopilotAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.test.ts
@@ -135,10 +135,10 @@ layer("CopilotAdapterLive startup", (it) => {
         runtimeMode: "approval-required",
       });
 
-      yield* Stream.runCollect(Stream.take(adapter.streamEvents, 8)).pipe(Effect.asVoid);
+      yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(Effect.asVoid);
 
       const runtimeEventsFiber = yield* Stream.runCollect(
-        Stream.take(adapter.streamEvents, 8),
+        Stream.take(adapter.streamEvents, 7),
       ).pipe(Effect.forkChild);
 
       const turn = yield* adapter.sendTurn({
@@ -232,6 +232,185 @@ layer("CopilotAdapterLive startup", (it) => {
       assert.equal(
         toolCompleted?.type === "item.completed" ? toolCompleted.payload.title : undefined,
         "bash",
+      );
+    }),
+  );
+
+  it.effect("waits for assistant usage before marking a Copilot turn complete", () =>
+    Effect.gen(function* () {
+      fakeClient.connected = false;
+      fakeClient.callLog.length = 0;
+      fakeClient.lastCreateSessionConfig = undefined;
+      fakeClient.session.handler = null;
+
+      const adapter = yield* CopilotAdapter;
+      yield* adapter.startSession({
+        provider: "copilot",
+        threadId: asThreadId("thread-copilot-usage-complete"),
+        model: "gpt-5.4",
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(Effect.asVoid);
+
+      const runtimeEventsFiber = yield* Stream.runCollect(
+        Stream.take(adapter.streamEvents, 7),
+      ).pipe(Effect.forkChild);
+
+      const turn = yield* adapter.sendTurn({
+        threadId: asThreadId("thread-copilot-usage-complete"),
+        input: "ship it",
+      });
+
+      fakeClient.session.emit({
+        id: "evt-turn-start-usage",
+        type: "assistant.turn_start",
+        timestamp: "2026-03-08T10:00:00.000Z",
+        data: {
+          turnId: "provider-turn-usage-1",
+        },
+      });
+
+      fakeClient.session.emit({
+        id: "evt-assistant-message-usage",
+        type: "assistant.message",
+        timestamp: "2026-03-08T10:00:01.000Z",
+        data: {
+          messageId: "msg-usage-1",
+          content: "Almost done",
+        },
+      });
+
+      fakeClient.session.emit({
+        id: "evt-turn-end-usage",
+        type: "assistant.turn_end",
+        timestamp: "2026-03-08T10:00:02.000Z",
+        data: {
+          turnId: "provider-turn-usage-1",
+        },
+      });
+
+      const sessionsAfterTurnEnd = yield* adapter.listSessions();
+      const currentSession = sessionsAfterTurnEnd.find(
+        (session) => session.threadId === "thread-copilot-usage-complete",
+      );
+      assert.equal(currentSession?.status, "running");
+      assert.equal(currentSession?.activeTurnId, turn.turnId);
+
+      fakeClient.session.emit({
+        id: "evt-usage",
+        type: "assistant.usage",
+        timestamp: "2026-03-08T10:00:03.000Z",
+        data: {
+          promptTokens: 10,
+          completionTokens: 12,
+          totalTokens: 22,
+          model: "gpt-5.4",
+        },
+      });
+
+      fakeClient.session.emit({
+        id: "evt-session-idle-usage",
+        type: "session.idle",
+        timestamp: "2026-03-08T10:00:04.000Z",
+        data: {},
+      });
+
+      const events = Array.from(
+        yield* Fiber.join(runtimeEventsFiber).pipe(
+          Effect.map((chunk): ReadonlyArray<ProviderRuntimeEvent> => Array.from(chunk)),
+        ),
+      );
+      const turnCompletedEvents = events.filter((event) => event.type === "turn.completed");
+
+      assert.equal(turnCompletedEvents.length, 1);
+      assert.equal(turnCompletedEvents[0]?.turnId, turn.turnId);
+      assert.equal(turnCompletedEvents[0]?.providerRefs?.providerTurnId, "provider-turn-usage-1");
+      assert.equal(
+        turnCompletedEvents[0]?.type === "turn.completed"
+          ? turnCompletedEvents[0].payload.modelUsage?.model
+          : undefined,
+        "gpt-5.4",
+      );
+    }),
+  );
+
+  it.effect("falls back to session idle to complete a Copilot turn when usage never arrives", () =>
+    Effect.gen(function* () {
+      fakeClient.connected = false;
+      fakeClient.callLog.length = 0;
+      fakeClient.lastCreateSessionConfig = undefined;
+      fakeClient.session.handler = null;
+
+      const adapter = yield* CopilotAdapter;
+      yield* adapter.startSession({
+        provider: "copilot",
+        threadId: asThreadId("thread-copilot-idle-complete"),
+        model: "gpt-5.4",
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(Effect.asVoid);
+
+      const runtimeEventsFiber = yield* Stream.runCollect(
+        Stream.take(adapter.streamEvents, 6),
+      ).pipe(Effect.forkChild);
+
+      const turn = yield* adapter.sendTurn({
+        threadId: asThreadId("thread-copilot-idle-complete"),
+        input: "wrap up",
+      });
+
+      fakeClient.session.emit({
+        id: "evt-turn-start-idle",
+        type: "assistant.turn_start",
+        timestamp: "2026-03-08T10:01:00.000Z",
+        data: {
+          turnId: "provider-turn-idle-1",
+        },
+      });
+
+      fakeClient.session.emit({
+        id: "evt-assistant-message-idle",
+        type: "assistant.message",
+        timestamp: "2026-03-08T10:01:01.000Z",
+        data: {
+          messageId: "msg-idle-1",
+          content: "Done",
+        },
+      });
+
+      fakeClient.session.emit({
+        id: "evt-turn-end-idle",
+        type: "assistant.turn_end",
+        timestamp: "2026-03-08T10:01:02.000Z",
+        data: {
+          turnId: "provider-turn-idle-1",
+        },
+      });
+
+      fakeClient.session.emit({
+        id: "evt-session-idle",
+        type: "session.idle",
+        timestamp: "2026-03-08T10:01:03.000Z",
+        data: {},
+      });
+
+      const events = Array.from(
+        yield* Fiber.join(runtimeEventsFiber).pipe(
+          Effect.map((chunk): ReadonlyArray<ProviderRuntimeEvent> => Array.from(chunk)),
+        ),
+      );
+      const turnCompletedEvents = events.filter((event) => event.type === "turn.completed");
+
+      assert.equal(turnCompletedEvents.length, 1);
+      assert.equal(turnCompletedEvents[0]?.turnId, turn.turnId);
+      assert.equal(turnCompletedEvents[0]?.providerRefs?.providerTurnId, "provider-turn-idle-1");
+      assert.equal(
+        turnCompletedEvents[0]?.type === "turn.completed"
+          ? turnCompletedEvents[0].payload.usage
+          : undefined,
+        undefined,
       );
     }),
   );

--- a/apps/server/src/provider/Layers/CopilotAdapter.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.ts
@@ -91,6 +91,8 @@ interface ActiveCopilotSession {
   lastError: string | undefined;
   currentTurnId: TurnId | undefined;
   currentProviderTurnId: TurnId | undefined;
+  pendingCompletionTurnId: TurnId | undefined;
+  pendingCompletionProviderTurnId: TurnId | undefined;
   pendingTurnIds: Array<TurnId>;
   toolTitlesByCallId: Map<string, string>;
   pendingApprovalResolvers: Map<string, PendingApprovalRequest>;
@@ -317,7 +319,7 @@ function mapHistoryToTurns(threadId: ThreadId, events: ReadonlyArray<SessionEven
     }
 
     current.items.push(event);
-    if (event.type === "assistant.turn_end" || event.type === "abort" || event.type === "session.idle") {
+    if (event.type === "assistant.usage" || event.type === "abort" || event.type === "session.idle") {
       current = undefined;
     }
   }
@@ -386,6 +388,24 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
     const writeNativeEvent = (threadId: ThreadId, event: SessionEvent) => {
       if (!nativeEventLogger) return Promise.resolve();
       return Effect.runPromise(nativeEventLogger.write(event, threadId)).catch(() => undefined);
+    };
+
+    const completionTurnRefs = (record: ActiveCopilotSession) => ({
+      turnId: record.pendingCompletionTurnId ?? record.currentTurnId,
+      providerTurnId: record.pendingCompletionProviderTurnId ?? record.currentProviderTurnId,
+    });
+
+    const markTurnAwaitingCompletion = (record: ActiveCopilotSession) => {
+      record.pendingCompletionTurnId = record.currentTurnId ?? record.pendingCompletionTurnId;
+      record.pendingCompletionProviderTurnId =
+        record.currentProviderTurnId ?? record.pendingCompletionProviderTurnId;
+    };
+
+    const clearTurnTracking = (record: ActiveCopilotSession) => {
+      record.currentTurnId = undefined;
+      record.currentProviderTurnId = undefined;
+      record.pendingCompletionTurnId = undefined;
+      record.pendingCompletionProviderTurnId = undefined;
     };
 
     const mapSessionEvent = (
@@ -485,8 +505,22 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
               },
             },
           ];
-        case "session.idle":
+        case "session.idle": {
+          const idleCompletionRefs = completionTurnRefs(record);
+          const idleCompletionEvents: ProviderRuntimeEvent[] =
+            idleCompletionRefs.turnId || idleCompletionRefs.providerTurnId
+              ? [
+                  {
+                    ...base(idleCompletionRefs),
+                    type: "turn.completed",
+                    payload: {
+                      state: "completed",
+                    },
+                  } satisfies ProviderRuntimeEvent,
+                ]
+              : [];
           return [
+            ...idleCompletionEvents,
             {
               ...base(),
               type: "session.state.changed",
@@ -504,6 +538,7 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
               },
             },
           ];
+        }
         case "session.title_changed":
           return [
             {
@@ -652,45 +687,51 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
             },
           ];
         case "assistant.turn_end":
+          return [];
+        case "assistant.usage": {
+          const completionRefs = completionTurnRefs(record);
+          const completionBase =
+            completionRefs.turnId || completionRefs.providerTurnId ? base(completionRefs) : base();
+          const completionEvents: ProviderRuntimeEvent[] =
+            completionRefs.turnId || completionRefs.providerTurnId
+              ? [
+                  {
+                    ...completionBase,
+                    type: "turn.completed",
+                    payload: {
+                      state: "completed",
+                      usage: event.data,
+                      ...(event.data.cost !== undefined ? { totalCostUsd: event.data.cost } : {}),
+                      ...(event.data.model ? { modelUsage: { model: event.data.model } } : {}),
+                    },
+                  } satisfies ProviderRuntimeEvent,
+                ]
+              : [];
           return [
+            ...completionEvents,
             {
-              ...base({ providerTurnId: toTurnId(event.data.turnId) }),
-              type: "turn.completed",
-              payload: {
-                state: "completed",
-              },
-            },
-          ];
-        case "assistant.usage":
-          return [
-            {
-              ...base(),
-              type: "turn.completed",
-              payload: {
-                state: "completed",
-                usage: event.data,
-                ...(event.data.cost !== undefined ? { totalCostUsd: event.data.cost } : {}),
-                ...(event.data.model ? { modelUsage: { model: event.data.model } } : {}),
-              },
-            },
-            {
-              ...base(),
+              ...completionBase,
               type: "thread.token-usage.updated",
               payload: {
                 usage: event.data,
               },
             },
           ];
-        case "abort":
+        }
+        case "abort": {
+          const abortedTurnRefs = completionTurnRefs(record);
+          const abortedBase =
+            abortedTurnRefs.turnId || abortedTurnRefs.providerTurnId ? base(abortedTurnRefs) : base();
           return [
             {
-              ...base(),
+              ...abortedBase,
               type: "turn.aborted",
               payload: {
                 reason: event.data.reason,
               },
             },
           ];
+        }
         case "tool.execution_start":
           return [
             {
@@ -1031,6 +1072,8 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
       lastError: undefined,
       currentTurnId: undefined,
       currentProviderTurnId: undefined,
+      pendingCompletionTurnId: undefined,
+      pendingCompletionProviderTurnId: undefined,
       pendingTurnIds: [],
       toolTitlesByCallId: new Map(),
       pendingApprovalResolvers: input.pendingApprovalResolvers,
@@ -1042,6 +1085,8 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
       record.updatedAt = event.timestamp;
       if (event.type === "assistant.turn_start") {
         const providerTurnId = TurnId.makeUnsafe(event.data.turnId);
+        record.pendingCompletionTurnId = undefined;
+        record.pendingCompletionProviderTurnId = undefined;
         record.currentProviderTurnId = providerTurnId;
         record.currentTurnId = record.pendingTurnIds.shift() ?? record.currentTurnId ?? providerTurnId;
       }
@@ -1063,9 +1108,11 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
       if (event.type === "tool.execution_complete") {
         record.toolTitlesByCallId.delete(event.data.toolCallId);
       }
-      if (event.type === "assistant.turn_end" || event.type === "abort" || event.type === "session.idle") {
-        record.currentTurnId = undefined;
-        record.currentProviderTurnId = undefined;
+      if (event.type === "assistant.turn_end") {
+        markTurnAwaitingCompletion(record);
+      }
+      if (event.type === "assistant.usage" || event.type === "abort" || event.type === "session.idle") {
+        clearTurnTracking(record);
       }
     };
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -134,14 +134,22 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   CircleAlertIcon,
+  DatabaseIcon,
+  EyeIcon,
   FileIcon,
   FolderIcon,
   DiffIcon,
   EllipsisIcon,
   FolderClosedIcon,
+  HammerIcon,
   LockIcon,
   LockOpenIcon,
+  SearchIcon,
+  SquarePenIcon,
+  TargetIcon,
+  TerminalIcon,
   Undo2Icon,
+  WrenchIcon,
   XIcon,
   CopyIcon,
   CheckIcon,
@@ -293,10 +301,91 @@ function readLastInvokedScriptByProjectFromStorage(): Record<string, string> {
 }
 
 function workToneClass(tone: "thinking" | "tool" | "info" | "error"): string {
-  if (tone === "error") return "text-rose-300/50 dark:text-rose-300/50";
-  if (tone === "tool") return "text-muted-foreground/70";
-  if (tone === "thinking") return "text-muted-foreground/50";
-  return "text-muted-foreground/40";
+  if (tone === "error") return "text-rose-400 dark:text-rose-300";
+  if (tone === "tool") return "text-foreground/80";
+  if (tone === "thinking") return "text-foreground/70";
+  return "text-muted-foreground/80";
+}
+
+function workToneIcon(tone: "thinking" | "tool" | "info" | "error") {
+  if (tone === "error") {
+    return {
+      icon: CircleAlertIcon,
+      className: "text-black/85 dark:text-white/90",
+    };
+  }
+  if (tone === "thinking") {
+    return {
+      icon: BotIcon,
+      className: "text-black/85 dark:text-white/90",
+    };
+  }
+  if (tone === "info") {
+    return {
+      icon: CheckIcon,
+      className: "text-black/85 dark:text-white/90",
+    };
+  }
+  return {
+    icon: ZapIcon,
+    className: "text-black/85 dark:text-white/90",
+  };
+}
+
+function workEntryPreview(workEntry: {
+  detail?: string;
+  command?: string;
+  changedFiles?: ReadonlyArray<string>;
+}): string | null {
+  if (workEntry.command) return workEntry.command;
+  if (workEntry.detail) return workEntry.detail;
+  if ((workEntry.changedFiles?.length ?? 0) > 0) {
+    const [firstPath] = workEntry.changedFiles ?? [];
+    if (!firstPath) return null;
+    return workEntry.changedFiles!.length === 1
+      ? firstPath
+      : `${firstPath} +${workEntry.changedFiles!.length - 1} more`;
+  }
+  return null;
+}
+
+function workEntryIcon(workEntry: {
+  label: string;
+  detail?: string;
+  command?: string;
+  tone: "thinking" | "tool" | "info" | "error";
+}) {
+  const haystack = [workEntry.label, workEntry.detail, workEntry.command]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join(" ")
+    .toLowerCase();
+
+  if (haystack.includes("report_intent") || haystack.includes("intent logged")) {
+    return TargetIcon;
+  }
+  if (
+    haystack.includes("bash") ||
+    haystack.includes("read_bash") ||
+    haystack.includes("write_bash") ||
+    haystack.includes("stop_bash") ||
+    haystack.includes("list_bash")
+  ) {
+    return TerminalIcon;
+  }
+  if (haystack.includes("sql")) return DatabaseIcon;
+  if (haystack.includes("view")) return EyeIcon;
+  if (haystack.includes("apply_patch")) return SquarePenIcon;
+  if (haystack.includes("rg") || haystack.includes("glob") || haystack.includes("search")) {
+    return SearchIcon;
+  }
+  if (haystack.includes("task")) return HammerIcon;
+  if (haystack.includes("skill")) return ZapIcon;
+  if (haystack.includes("ask_user") || haystack.includes("approval")) return BotIcon;
+  if (haystack.includes("store_memory")) return FolderIcon;
+  if (haystack.includes("edit") || haystack.includes("patch")) return WrenchIcon;
+  if (haystack.includes("file")) return FileIcon;
+
+  return workToneIcon(workEntry.tone).icon;
 }
 
 function normalizePlanMarkdownForExport(planMarkdown: string): string {
@@ -1223,29 +1312,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     return byUserMessageId;
   }, [inferredCheckpointTurnCountByTurnId, timelineEntries, turnDiffSummaryByAssistantMessageId]);
 
-  const completionSummary = useMemo(() => {
-    if (!latestTurnSettled) return null;
-    if (!activeLatestTurn?.completedAt) return null;
-    if (workLogEntries.length === 0) return null;
-
-    const summaryStartAt =
-      latestUserMessageCreatedAt ?? workLogEntries[0]?.createdAt ?? activeLatestTurn.startedAt;
-    if (!summaryStartAt) return null;
-
-    const elapsed = formatElapsed(summaryStartAt, activeLatestTurn.completedAt);
-    return elapsed ? `Worked for ${elapsed}` : null;
-  }, [
-    activeLatestTurn?.completedAt,
-    activeLatestTurn?.startedAt,
-    latestTurnSettled,
-    latestUserMessageCreatedAt,
-    workLogEntries,
-  ]);
   const completionDividerBeforeEntryId = useMemo(() => {
     if (!latestTurnSettled) return null;
     if (!activeLatestTurn?.startedAt) return null;
     if (!activeLatestTurn.completedAt) return null;
-    if (!completionSummary) return null;
+    if (workLogEntries.length === 0) return null;
 
     const turnStartedAt = Date.parse(activeLatestTurn.startedAt);
     const turnCompletedAt = Date.parse(activeLatestTurn.completedAt);
@@ -1268,9 +1339,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
   }, [
     activeLatestTurn?.completedAt,
     activeLatestTurn?.startedAt,
-    completionSummary,
     latestTurnSettled,
     timelineEntries,
+    workLogEntries.length,
   ]);
   const gitCwd = activeThread?.worktreePath ?? activeProject?.cwd ?? null;
   const composerTriggerKind = composerTrigger?.kind ?? null;
@@ -3560,7 +3631,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
           scrollContainer={messagesScrollElement}
           timelineEntries={timelineEntries}
           completionDividerBeforeEntryId={completionDividerBeforeEntryId}
-          completionSummary={completionSummary}
           turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
           nowIso={nowIso}
           expandedWorkGroups={expandedWorkGroups}
@@ -4837,7 +4907,6 @@ interface MessagesTimelineProps {
   scrollContainer: HTMLDivElement | null;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
   completionDividerBeforeEntryId: string | null;
-  completionSummary: string | null;
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
   nowIso: string;
   expandedWorkGroups: Record<string, boolean>;
@@ -4891,7 +4960,6 @@ const MessagesTimeline = memo(function MessagesTimeline({
   scrollContainer,
   timelineEntries,
   completionDividerBeforeEntryId,
-  completionSummary,
   turnDiffSummaryByAssistantMessageId,
   nowIso,
   expandedWorkGroups,
@@ -5116,73 +5184,95 @@ const MessagesTimeline = memo(function MessagesTimeline({
               : groupedEntries;
           const hiddenCount = groupedEntries.length - visibleEntries.length;
           const onlyToolEntries = groupedEntries.every((entry) => entry.tone === "tool");
-          const groupLabel = onlyToolEntries
-            ? groupedEntries.length === 1
-              ? "Tool call"
-              : `Tool calls (${groupedEntries.length})`
-            : groupedEntries.length === 1
-              ? "Work event"
-              : `Work log (${groupedEntries.length})`;
+          const showHeader = hasOverflow || !onlyToolEntries;
+          const groupLabel = onlyToolEntries ? "Tool calls" : "Work log";
 
           return (
-            <div className="rounded-lg border border-border/80 bg-card/45 px-3 py-2">
-              <div className="mb-1.5 flex items-center justify-between gap-3">
-                <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
-                  {groupLabel}
-                </p>
-                {hasOverflow && (
-                  <button
-                    type="button"
-                    className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/55 transition-colors duration-150 hover:text-muted-foreground/80"
-                    onClick={() => onToggleWorkGroup(groupId)}
-                  >
-                    {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
-                  </button>
-                )}
-              </div>
-              <div className="space-y-1">
-                {visibleEntries.map((workEntry) => (
-                  <div key={`work-row:${workEntry.id}`} className="flex items-start gap-2 py-0.5">
-                    <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
-                    <div className="min-w-0 flex-1 py-[2px]">
-                      <p className={`text-[11px] leading-relaxed ${workToneClass(workEntry.tone)}`}>
-                        {workEntry.label}
-                      </p>
-                      {workEntry.command && (
-                        <pre className="mt-1 overflow-x-auto rounded-md border border-border/70 bg-background/80 px-2 py-1 font-mono text-[11px] leading-relaxed text-foreground/80">
-                          {workEntry.command}
-                        </pre>
-                      )}
-                      {workEntry.changedFiles && workEntry.changedFiles.length > 0 && (
-                        <div className="mt-1 flex flex-wrap gap-1">
-                          {workEntry.changedFiles.slice(0, 6).map((filePath) => (
+            <div className="rounded-xl border border-border/45 bg-card/25 px-2 py-1.5">
+              {showHeader && (
+                <div className="mb-1.5 flex items-center justify-between gap-2 px-0.5">
+                  <p className="text-[9px] uppercase tracking-[0.16em] text-muted-foreground/55">
+                    {groupLabel} ({groupedEntries.length})
+                  </p>
+                  {hasOverflow && (
+                    <button
+                      type="button"
+                      className="text-[9px] uppercase tracking-[0.12em] text-muted-foreground/55 transition-colors duration-150 hover:text-foreground/75"
+                      onClick={() => onToggleWorkGroup(groupId)}
+                    >
+                      {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
+                    </button>
+                  )}
+                </div>
+              )}
+              <div className="space-y-0.5">
+                {visibleEntries.map((workEntry, workEntryIndex) => {
+                  const iconConfig = workToneIcon(workEntry.tone);
+                  const EntryIcon = workEntryIcon(workEntry);
+                  const preview = workEntryPreview(workEntry);
+                  const displayText = preview ? `${workEntry.label} - ${preview}` : workEntry.label;
+                  const hasChangedFiles = (workEntry.changedFiles?.length ?? 0) > 0;
+                  const previewIsChangedFiles =
+                    hasChangedFiles && !workEntry.command && !workEntry.detail;
+                  return (
+                    <div
+                      key={`work-row:${workEntry.id}`}
+                      className="animate-in fade-in slide-in-from-bottom-1 rounded-lg px-1 py-1 duration-200"
+                      style={{
+                        animationDelay: `${Math.min(workEntryIndex, 4) * 40}ms`,
+                      }}
+                    >
+                      <div className="flex items-center gap-2 transition-[opacity,translate] duration-200">
+                        <span
+                          className={cn(
+                            "flex size-5 shrink-0 items-center justify-center",
+                            iconConfig.className,
+                          )}
+                        >
+                          <EntryIcon className="size-3" />
+                        </span>
+                        <div className="min-w-0 flex-1 overflow-hidden animate-in fade-in duration-300">
+                          <p
+                            className={cn(
+                              "truncate text-[11px] leading-5",
+                              workToneClass(workEntry.tone),
+                              preview ? "text-muted-foreground/70" : "",
+                            )}
+                            title={displayText}
+                          >
+                            <span className={cn("text-foreground/80", workToneClass(workEntry.tone))}>
+                              {workEntry.label}
+                            </span>
+                            {preview && (
+                              <span className="text-muted-foreground/55"> - {preview}</span>
+                            )}
+                          </p>
+                        </div>
+                        <span className="shrink-0 text-[9px] text-muted-foreground/35">
+                          {formatTimestamp(workEntry.createdAt)}
+                        </span>
+                      </div>
+                      {hasChangedFiles && !previewIsChangedFiles && (
+                        <div className="animate-in fade-in slide-in-from-bottom-1 mt-1 flex flex-wrap gap-1 pl-6 duration-200">
+                          {workEntry.changedFiles?.slice(0, 4).map((filePath) => (
                             <span
                               key={`${workEntry.id}:${filePath}`}
-                              className="rounded-md border border-border/70 bg-background/65 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/85"
+                              className="rounded-md border border-border/55 bg-background/55 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/75"
                               title={filePath}
                             >
                               {filePath}
                             </span>
                           ))}
-                          {workEntry.changedFiles.length > 6 && (
-                            <span className="px-1 text-[10px] text-muted-foreground/65">
-                              +{workEntry.changedFiles.length - 6} more
+                          {(workEntry.changedFiles?.length ?? 0) > 4 && (
+                            <span className="px-1 text-[10px] text-muted-foreground/55">
+                              +{(workEntry.changedFiles?.length ?? 0) - 4}
                             </span>
                           )}
                         </div>
                       )}
-                      {workEntry.detail &&
-                        (!workEntry.command || workEntry.detail !== workEntry.command) && (
-                          <p
-                            className="mt-1 text-[11px] leading-relaxed text-muted-foreground/75"
-                            title={workEntry.detail}
-                          >
-                            {workEntry.detail}
-                          </p>
-                        )}
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           );
@@ -5271,11 +5361,12 @@ const MessagesTimeline = memo(function MessagesTimeline({
             <>
               {row.showCompletionDivider && (
                 <div className="my-3 flex items-center gap-3">
-                  <span className="h-px flex-1 bg-border" />
-                  <span className="rounded-full border border-border bg-background px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
-                    {completionSummary ? `Response • ${completionSummary}` : "Response"}
+                  <span className="h-px flex-1 bg-border/80" />
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background/90 px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground/80 shadow-sm">
+                    <BotIcon className="size-3" />
+                    Assistant response
                   </span>
-                  <span className="h-px flex-1 bg-border" />
+                  <span className="h-px flex-1 bg-border/80" />
                 </div>
               )}
               <div className="min-w-0 px-1 py-0.5">


### PR DESCRIPTION
Keep Copilot turns pending until usage or session-idle arrives so completion events retain the right turn refs, and refresh the work log presentation to better surface tool progress and assistant response boundaries.