### PR TITLE
fix: handle turn.aborted in ProviderRuntimeIngestion to unblock Copilot stop

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1784,4 +1784,44 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.status).toBe("running");
     expect(thread.session?.activeTurnId).toBe("turn-after-abort");
   });
+
+  it("ignores a late turn.aborted for a different turn than the active one", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    // Start turn-2 so it becomes the active turn.
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-active"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-2"),
+    });
+
+    await waitForThread(
+      harness.engine,
+      (thread) => thread.session?.status === "running" && thread.session?.activeTurnId === "turn-2",
+    );
+
+    // A late abort arrives for a stale turn (turn-1) — should be ignored.
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted-stale"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId: asTurnId("turn-1"),
+      payload: { reason: "late abort" },
+    });
+
+    // Allow event processing to settle, then verify state is unchanged.
+    await harness.drain();
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) => entry.session?.status === "running" && entry.session?.activeTurnId === "turn-2",
+    );
+    expect(thread.session?.status).toBe("running");
+    expect(thread.session?.activeTurnId).toBe("turn-2");
+  });
 });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1041,7 +1041,10 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (event.type === "turn.completed" || event.type === "turn.aborted") {
+      if (
+        (event.type === "turn.completed" || event.type === "turn.aborted") &&
+        shouldApplyThreadLifecycle
+      ) {
         const turnId = toTurnId(event.turnId);
         if (turnId) {
           const assistantMessageIds = yield* getAssistantMessageIdsForTurn(thread.id, turnId);


### PR DESCRIPTION
## Problem

When the user clicks the stop button during a Copilot turn, `CopilotAdapter` calls `session.abort()` on the Copilot SDK which emits a `turn.aborted` runtime event. However, `ProviderRuntimeIngestion` only handled `turn.completed` for lifecycle transitions — leaving the session stuck in `"running"` with a stale `activeTurnId`, which blocked all subsequent sends.

## Fix

Added `turn.aborted` alongside `turn.completed` in four lifecycle handling paths within `ProviderRuntimeIngestion.ts`:

1. **`shouldApplyThreadLifecycle` guard** — allows the abort event through the strict lifecycle filter
2. **Lifecycle event condition & `activeTurnId` clearing** — clears the active turn on abort
3. **Status derivation** — maps `turn.aborted` → `"interrupted"` (which the UI maps to `"ready"` phase, re-enabling the input)
4. **Turn finalization** — finalizes buffered assistant messages and proposed plans on abort

## Tests

Two new tests in `ProviderRuntimeIngestion.test.ts`:
- `turn.aborted` transitions session to `"interrupted"` with `activeTurnId` cleared
- After abort, a new `turn.started` successfully transitions back to `"running"`

All 25 tests pass. Typecheck and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handle aborted turns by marking sessions as interrupted, clearing the active turn, and allowing sessions to resume and accept new turns.
  * Treat aborted turns like completed ones for lifecycle, finalization, and error-state handling.
* **Tests**
  * Added tests for aborted-turn mapping, session recovery after abort, and ignoring late aborts for non-active turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->