### PR TITLE
feat(web): add tool output/diff visibility setting

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getAppSettingsSnapshot,
   getAppModelOptions,
   getSlashModelOptions,
   normalizeCustomModelSlugs,
@@ -70,5 +71,12 @@ describe("getSlashModelOptions", () => {
     const options = getSlashModelOptions("codex", ["openai/gpt-oss-120b"], "oss", "gpt-5.3-codex");
 
     expect(options.map((option) => option.slug)).toEqual(["openai/gpt-oss-120b"]);
+  });
+});
+
+describe("getAppSettingsSnapshot", () => {
+  it("defaults tool output and diff visibility to enabled", () => {
+    const settings = getAppSettingsSnapshot();
+    expect(settings.showToolOutputAndDiff).toBe(true);
   });
 });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -28,6 +28,9 @@ const AppSettingsSchema = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(
     Schema.withConstructorDefault(() => Option.some(false)),
   ),
+  showToolOutputAndDiff: Schema.Boolean.pipe(
+    Schema.withConstructorDefault(() => Option.some(true)),
+  ),
   customCodexModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
   ),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -488,9 +488,10 @@ function summarizeToolOutput(value: string, limit = 96): string {
 function collapsedToolWorkEntryPreview(
   workEntry: WorkLogEntry,
   primaryPath: string | null,
+  showToolOutputAndDiff: boolean,
 ): string | null {
   if (workEntry.itemType === "command_execution" || workEntry.requestKind === "command") {
-    if (workEntry.output) {
+    if (showToolOutputAndDiff && workEntry.output) {
       return summarizeToolOutput(workEntry.output);
     }
     if (workEntry.command) {
@@ -503,7 +504,7 @@ function collapsedToolWorkEntryPreview(
   if (workEntry.command) {
     return workEntry.command;
   }
-  if (workEntry.output) {
+  if (showToolOutputAndDiff && workEntry.output) {
     return summarizeToolOutput(workEntry.output);
   }
   if (workEntry.detail) {
@@ -519,8 +520,10 @@ function isRichToolWorkEntry(workEntry: WorkLogEntry): boolean {
 const ToolWorkEntryRow = memo(function ToolWorkEntryRow(props: {
   workEntry: WorkLogEntry;
   workEntryIndex: number;
+  showToolOutputAndDiff: boolean;
+  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
 }) {
-  const { workEntry, workEntryIndex } = props;
+  const { workEntry, workEntryIndex, showToolOutputAndDiff, onOpenTurnDiff } = props;
   const [open, setOpen] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
   const EntryIcon = workEntryIcon(workEntry);
@@ -531,13 +534,20 @@ const ToolWorkEntryRow = memo(function ToolWorkEntryRow(props: {
     workEntry.changedFiles?.slice(primaryPath ? 1 : 0, primaryPath ? 4 : 4) ?? [];
   const hiddenPathCount =
     (workEntry.changedFiles?.length ?? 0) - additionalPaths.length - (primaryPath ? 1 : 0);
-  const preview = collapsedToolWorkEntryPreview(workEntry, primaryPath);
+  const diffTurnId = workEntry.turnId ?? null;
+  const canOpenFileDiff = Boolean(
+    showToolOutputAndDiff &&
+    diffTurnId &&
+    (workEntry.itemType === "file_change" || workEntry.requestKind === "file-change"),
+  );
+  const preview = collapsedToolWorkEntryPreview(workEntry, primaryPath, showToolOutputAndDiff);
   const displayText = preview ? `${heading} - ${preview}` : heading;
   const hasExpandedDetails = Boolean(
     workEntry.command ||
     primaryPath ||
     additionalPaths.length > 0 ||
-    workEntry.output ||
+    (showToolOutputAndDiff && workEntry.output) ||
+    canOpenFileDiff ||
     typeof workEntry.exitCode === "number",
   );
 
@@ -637,7 +647,20 @@ const ToolWorkEntryRow = memo(function ToolWorkEntryRow(props: {
         </div>
       )}
 
-      {workEntry.output && (
+      {canOpenFileDiff && diffTurnId && (
+        <div>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => onOpenTurnDiff(diffTurnId, primaryPath ?? workEntry.changedFiles?.[0])}
+          >
+            View diff
+          </Button>
+        </div>
+      )}
+
+      {showToolOutputAndDiff && workEntry.output && (
         <div className="rounded-md border border-border/55 bg-background/75 px-2.5 py-2">
           <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[10px] leading-4 text-foreground/78">
             {workEntry.output}
@@ -4145,6 +4168,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
               expandedWorkGroups={expandedWorkGroups}
               onToggleWorkGroup={onToggleWorkGroup}
               onOpenTurnDiff={onOpenTurnDiff}
+              showToolOutputAndDiff={settings.showToolOutputAndDiff}
               revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
               onRevertUserMessage={onRevertUserMessage}
               isRevertingCheckpoint={isRevertingCheckpoint}
@@ -5614,6 +5638,7 @@ interface MessagesTimelineProps {
   expandedWorkGroups: Record<string, boolean>;
   onToggleWorkGroup: (groupId: string) => void;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+  showToolOutputAndDiff: boolean;
   revertTurnCountByUserMessageId: Map<MessageId, number>;
   onRevertUserMessage: (messageId: MessageId) => void;
   isRevertingCheckpoint: boolean;
@@ -5668,6 +5693,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
   expandedWorkGroups,
   onToggleWorkGroup,
   onOpenTurnDiff,
+  showToolOutputAndDiff,
   revertTurnCountByUserMessageId,
   onRevertUserMessage,
   isRevertingCheckpoint,
@@ -5915,6 +5941,8 @@ const MessagesTimeline = memo(function MessagesTimeline({
                       key={`work-row:${workEntry.id}`}
                       workEntry={workEntry}
                       workEntryIndex={workEntryIndex}
+                      showToolOutputAndDiff={showToolOutputAndDiff}
+                      onOpenTurnDiff={onOpenTurnDiff}
                     />
                   ) : (
                     <SimpleWorkEntryRow

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -479,6 +479,40 @@ function SettingsRouteView() {
                   </Button>
                 </div>
               ) : null}
+
+              <div className="mt-3 flex items-center justify-between rounded-lg border border-border bg-background px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium text-foreground">Show tool output and diffs</p>
+                  <p className="text-xs text-muted-foreground">
+                    Show command output and file-change diff actions in tool call work logs.
+                  </p>
+                </div>
+                <Switch
+                  checked={settings.showToolOutputAndDiff}
+                  onCheckedChange={(checked) =>
+                    updateSettings({
+                      showToolOutputAndDiff: Boolean(checked),
+                    })
+                  }
+                  aria-label="Show tool output and diffs"
+                />
+              </div>
+
+              {settings.showToolOutputAndDiff !== defaults.showToolOutputAndDiff ? (
+                <div className="mt-3 flex justify-end">
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={() =>
+                      updateSettings({
+                        showToolOutputAndDiff: defaults.showToolOutputAndDiff,
+                      })
+                    }
+                  >
+                    Restore default
+                  </Button>
+                </div>
+              ) : null}
             </section>
 
             <section className="rounded-2xl border border-border bg-card p-5">

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -491,6 +491,7 @@ describe("deriveWorkLogEntries", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "file-tool",
+        turnId: "turn-file-change",
         kind: "tool.completed",
         summary: "File change complete",
         payload: {
@@ -512,6 +513,7 @@ describe("deriveWorkLogEntries", () => {
       "apps/web/src/components/ChatView.tsx",
       "apps/web/src/session-logic.ts",
     ]);
+    expect(entry?.turnId).toBe("turn-file-change");
   });
 
   it("keeps tool item types for icon rendering", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -32,6 +32,7 @@ export const PROVIDER_OPTIONS: Array<{
 export interface WorkLogEntry {
   id: string;
   createdAt: string;
+  turnId?: TurnId | null;
   label: string;
   detail?: string;
   output?: string;
@@ -448,6 +449,7 @@ export function deriveWorkLogEntries(
       const entry: WorkLogEntry = {
         id: activity.id,
         createdAt: activity.createdAt,
+        turnId: activity.turnId,
         label: activity.summary,
         tone: activity.tone === "approval" ? "info" : activity.tone,
         activityKind: activity.kind,


### PR DESCRIPTION
## Summary
- add showToolOutputAndDiff app setting (default enabled)
- add settings toggle to control tool output and file-change diff action visibility
- include turnId in derived work log entries to support diff navigation from tool rows
- gate command output rendering in rich tool rows and add View diff action for file-change/apply-change rows
- add regression coverage in app settings and session logic tests

## Validation
- bun run test --filter=@t3tools/web -- src/appSettings.test.ts src/session-logic.test.ts
- bun fmt
- bun lint
- bun typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new settings toggle "Show tool output and diffs" to control the visibility of tool outputs and file differences in the chat interface.
  * Added a "View diff" button enabling users to view per-turn file changes.

* **Tests**
  * Added test coverage for the new tool output and diff setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->