### PR TITLE
Fix Windows Copilot health check startup

### DIFF
--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -6,6 +6,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   checkCodexProviderStatus,
+  getCopilotHealthCheckTimeoutMs,
   hasCustomModelProvider,
   parseAuthStatusFromOutput,
   readCodexConfigModelProvider,
@@ -463,5 +464,13 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
         assert.strictEqual(yield* hasCustomModelProvider, true);
       }),
     );
+  });
+
+  describe("getCopilotHealthCheckTimeoutMs", () => {
+    it("uses a longer startup timeout on Windows", () => {
+      assert.strictEqual(getCopilotHealthCheckTimeoutMs("darwin"), 4_000);
+      assert.strictEqual(getCopilotHealthCheckTimeoutMs("linux"), 4_000);
+      assert.strictEqual(getCopilotHealthCheckTimeoutMs("win32"), 10_000);
+    });
   });
 });

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -32,6 +32,10 @@ const DEFAULT_TIMEOUT_MS = 4_000;
 const CODEX_PROVIDER = "codex" as const;
 const COPILOT_PROVIDER = "copilot" as const;
 
+export function getCopilotHealthCheckTimeoutMs(platform: string = process.platform): number {
+  return platform === "win32" ? 10_000 : DEFAULT_TIMEOUT_MS;
+}
+
 // ── Pure helpers ────────────────────────────────────────────────────
 
 export interface CommandResult {
@@ -498,7 +502,7 @@ export const checkCopilotProviderStatus: Effect.Effect<ServerProviderStatus> = E
           _tag: "CopilotHealthProbeError",
           cause,
         }) satisfies CopilotHealthProbeError,
-    }).pipe(Effect.timeoutOption(DEFAULT_TIMEOUT_MS), Effect.result);
+    }).pipe(Effect.timeoutOption(getCopilotHealthCheckTimeoutMs()), Effect.result);
 
     if (Result.isFailure(probe)) {
       const error = probe.failure.cause;

--- a/apps/server/src/provider/Layers/copilotCliPath.test.ts
+++ b/apps/server/src/provider/Layers/copilotCliPath.test.ts
@@ -1,0 +1,72 @@
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveBundledCopilotCliPathFrom } from "./copilotCliPath.ts";
+
+const CURRENT_DIR = "/repo/apps/server/src/provider/Layers";
+const SDK_ENTRYPOINT = "/repo/apps/server/node_modules/@github/copilot-sdk/dist/index.js";
+
+describe("copilotCliPath", () => {
+  it("prefers the SDK JavaScript entrypoint on Windows", () => {
+    const jsEntrypoint = join("/repo/apps/server/node_modules", "@github", "copilot", "index.js");
+    const binaryPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot-win32-x64",
+      "copilot.exe",
+    );
+    const existingPaths = new Set([jsEntrypoint, binaryPath]);
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        currentDir: CURRENT_DIR,
+        sdkEntrypoint: SDK_ENTRYPOINT,
+        platform: "win32",
+        arch: "x64",
+        exists: (candidate) => existingPaths.has(candidate),
+      }),
+    ).toBe(jsEntrypoint);
+  });
+
+  it("keeps the native binary preference on non-Windows platforms", () => {
+    const jsEntrypoint = join("/repo/apps/server/node_modules", "@github", "copilot", "index.js");
+    const binaryPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot-linux-x64",
+      "copilot",
+    );
+    const existingPaths = new Set([jsEntrypoint, binaryPath]);
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        currentDir: CURRENT_DIR,
+        sdkEntrypoint: SDK_ENTRYPOINT,
+        platform: "linux",
+        arch: "x64",
+        exists: (candidate) => existingPaths.has(candidate),
+      }),
+    ).toBe(binaryPath);
+  });
+
+  it("does not fall back to npm-loader.js for SDK launches", () => {
+    const npmLoaderPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot",
+      "npm-loader.js",
+    );
+    const existingPaths = new Set([npmLoaderPath]);
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        currentDir: CURRENT_DIR,
+        sdkEntrypoint: SDK_ENTRYPOINT,
+        platform: "win32",
+        arch: "x64",
+        exists: (candidate) => existingPaths.has(candidate),
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/server/src/provider/Layers/copilotCliPath.ts
+++ b/apps/server/src/provider/Layers/copilotCliPath.ts
@@ -7,6 +7,7 @@ const require = createRequire(import.meta.url);
 const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
 const GITHUB_SCOPE_DIR = "@github";
 const COPILOT_PATHLESS_COMMAND_PATTERN = /^copilot(?:\.(?:exe|cmd|bat))?$/i;
+const COPILOT_SDK_ENTRYPOINT = "index.js";
 
 function dedupePaths(paths: ReadonlyArray<string | undefined>): string[] {
   const resolved: string[] = [];
@@ -130,16 +131,15 @@ export function resolveBundledCopilotCliPathFrom(input: {
   const binaryCandidates = nodeModulesRoots.flatMap((root) =>
     platformPackages.map((packageName) => join(root, GITHUB_SCOPE_DIR, packageName, binaryName)),
   );
-  for (const candidate of dedupePaths(binaryCandidates)) {
-    if (exists(candidate)) {
-      return candidate;
-    }
-  }
-
-  const npmLoaderCandidates = dedupePaths(
-    nodeModulesRoots.map((root) => join(root, GITHUB_SCOPE_DIR, "copilot", "npm-loader.js")),
+  const jsEntrypointCandidates = nodeModulesRoots.map((root) =>
+    join(root, GITHUB_SCOPE_DIR, "copilot", COPILOT_SDK_ENTRYPOINT),
   );
-  for (const candidate of npmLoaderCandidates) {
+  const preferredCandidates =
+    platform === "win32"
+      ? dedupePaths([...jsEntrypointCandidates, ...binaryCandidates])
+      : dedupePaths([...binaryCandidates, ...jsEntrypointCandidates]);
+
+  for (const candidate of preferredCandidates) {
     if (exists(candidate)) {
       return candidate;
     }
@@ -153,14 +153,18 @@ export function resolveBundledCopilotCliPathFrom(input: {
   const sdkSiblingBinaryCandidates = platformPackages.map((packageName) =>
     join(githubScopeDir, packageName, binaryName),
   );
-  for (const candidate of dedupePaths(sdkSiblingBinaryCandidates)) {
+  const sdkSiblingJsEntrypoint = join(githubScopeDir, "copilot", COPILOT_SDK_ENTRYPOINT);
+  const preferredSdkSiblingCandidates =
+    platform === "win32"
+      ? dedupePaths([sdkSiblingJsEntrypoint, ...sdkSiblingBinaryCandidates])
+      : dedupePaths([...sdkSiblingBinaryCandidates, sdkSiblingJsEntrypoint]);
+
+  for (const candidate of preferredSdkSiblingCandidates) {
     if (exists(candidate)) {
       return candidate;
     }
   }
-
-  const sdkSiblingLoaderPath = join(githubScopeDir, "copilot", "npm-loader.js");
-  return exists(sdkSiblingLoaderPath) ? sdkSiblingLoaderPath : undefined;
+  return undefined;
 }
 
 export function resolveBundledCopilotCliPath(): string | undefined {


### PR DESCRIPTION
## Summary
- prefer the Copilot SDK JavaScript entrypoint on Windows instead of falling back to npm-loader.js
- extend the Windows Copilot startup health-check timeout to reduce false failures while loading metadata
- add regression tests for Windows CLI path resolution and timeout selection

## Validation
- bun fmt
- bun lint
- bun typecheck
- cd apps/server && bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Copilot health check reliability through OS-specific timeout configuration, with optimized durations for different platforms
  * Enhanced Copilot CLI path resolution with platform-aware entrypoint preferences for better application startup

* **Tests**
  * Added comprehensive test coverage for OS-specific health check timeout behavior and platform-dependent CLI path resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->