### PR TITLE
fix(web): use selected provider for pre-session health banner

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveProviderHealthBannerProvider } from "./ChatView.logic";
+
+describe("resolveProviderHealthBannerProvider", () => {
+  it("uses the active session provider when a session exists", () => {
+    expect(
+      resolveProviderHealthBannerProvider({
+        sessionProvider: "codex",
+        selectedProvider: "copilot",
+      }),
+    ).toBe("codex");
+  });
+
+  it("uses selected draft provider before session starts", () => {
+    expect(
+      resolveProviderHealthBannerProvider({
+        sessionProvider: null,
+        selectedProvider: "copilot",
+      }),
+    ).toBe("copilot");
+  });
+});

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -125,3 +125,10 @@ export function getCustomModelOptionsByProvider(settings: {
     copilot: getAppModelOptions("copilot", settings.customCopilotModels),
   };
 }
+
+export function resolveProviderHealthBannerProvider(input: {
+  sessionProvider: ProviderKind | null;
+  selectedProvider: ProviderKind;
+}): ProviderKind {
+  return input.sessionProvider ?? input.selectedProvider;
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -249,6 +249,7 @@ import {
   computeMessageDurationStart,
   normalizeCompactToolLabel,
 } from "./chat/MessagesTimeline.logic";
+import { resolveProviderHealthBannerProvider } from "./ChatView.logic";
 
 function formatMessageMeta(
   createdAt: string,
@@ -1981,7 +1982,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
   const availableEditors = serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
-  const activeProvider = activeThread?.session?.provider ?? "codex";
+  const activeProvider = resolveProviderHealthBannerProvider({
+    sessionProvider: activeThread?.session?.provider ?? null,
+    selectedProvider,
+  });
   const activeProviderStatus = useMemo(
     () => providerStatuses.find((status) => status.provider === activeProvider) ?? null,
     [activeProvider, providerStatuses],


### PR DESCRIPTION
## What Changed

- Added a small UI-only helper in `apps/web/src/components/ChatView.logic.ts` to resolve which provider’s health banner should be shown.
- Updated `apps/web/src/components/ChatView.tsx` so that when a thread has no active session yet (pre-session), the banner follows the currently selected draft provider instead of defaulting to Codex.
- Added regression tests in `apps/web/src/components/ChatView.logic.test.ts` to cover:
  - session provider takes priority when present
  - selected draft provider is used before session start

## Why

When creating a new thread from the sidebar `+`, the thread starts in a pre-session state; previously, banner provider resolution fell back to Codex, which could show:

> Codex CLI (`codex`) is not installed or not on PATH.

for Copilot-first workflows where Codex is intentionally not installed.

This change keeps behavior minimal and focused: it only adjusts banner-provider resolution in the web UI and does not modify provider runtime/server protocol flow.

## UI Changes

**Before** (Codex warning shown even in Copilot workflow pre-session):

<img width="1594" height="1028" alt="Before: Codex warning in pre-session draft thread" src="https://github.com/user-attachments/assets/b61b814a-21fd-4fff-944f-3afc3147310d" />

**After**:
- In pre-session draft threads, provider health banner now follows the selected draft provider.
- Codex warning is no longer shown unless Codex is actually the active/intended provider.

With Copilot: 
<img width="1777" height="992" alt="260313_20h40m44s_screenshot" src="https://github.com/user-attachments/assets/30461c72-02ed-4942-abf1-0d4ae9aa277a" />

With Codex:
<img width="1880" height="1001" alt="260313_20h42m45s_screenshot" src="https://github.com/user-attachments/assets/abfc9f5a-5e31-4996-8e25-a70b9bcdaf44" />


<!-- Add an after screenshot here if possible -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes (before included, after can be added)
- [x] I included a video for animation/interaction changes (N/A — no animation/interaction behavior changed)

Refs #24 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for provider health banner selection logic, covering multiple scenarios including active session handling and fallback provider selection.

* **Refactor**
  * Refactored provider resolution logic by extracting the selection mechanism into a dedicated helper function to enhance code maintainability, testability, and overall separation of concerns across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->