### PR TITLE
fix: load Copilot MCP servers into SDK sessions

### DIFF
--- a/apps/server/src/provider/Layers/CopilotAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { ThreadId } from "@t3tools/contracts";
 import { type SessionEvent } from "@github/copilot-sdk";
@@ -90,8 +93,10 @@ class FakeCopilotSession {
 class FakeCopilotClient {
   public readonly startImpl = vi.fn(async () => undefined);
   public readonly listModelsImpl = vi.fn(async () => []);
-  public readonly createSessionImpl = vi.fn(async () => this.session);
-  public readonly resumeSessionImpl = vi.fn(async () => this.session);
+  public readonly createSessionImpl = vi.fn(async (_config: unknown) => this.session);
+  public readonly resumeSessionImpl = vi.fn(
+    async (_sessionId: string, _config: unknown) => this.session,
+  );
   public readonly stopImpl = vi.fn(async () => [] as Error[]);
 
   constructor(private readonly session: FakeCopilotSession) {}
@@ -104,12 +109,12 @@ class FakeCopilotClient {
     return this.listModelsImpl();
   }
 
-  createSession(_config: unknown) {
-    return this.createSessionImpl();
+  createSession(config: unknown) {
+    return this.createSessionImpl(config);
   }
 
-  resumeSession(_sessionId: string, _config: unknown) {
-    return this.resumeSessionImpl();
+  resumeSession(sessionId: string, config: unknown) {
+    return this.resumeSessionImpl(sessionId, config);
   }
 
   stop() {
@@ -233,9 +238,76 @@ planLayer("CopilotAdapterLive proposed plan events", (it) => {
   );
 });
 
+const mcpSession = new FakeCopilotSession("copilot-session-mcp");
+const mcpClient = new FakeCopilotClient(mcpSession);
+const mcpLayer = it.layer(
+  makeCopilotAdapterLive({
+    clientFactory: () => mcpClient,
+  }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+mcpLayer("CopilotAdapterLive MCP config loading", (it) => {
+  it.effect("passes local MCP servers from mcp-config.json to the SDK", () =>
+    Effect.gen(function* () {
+      const configDir = mkdtempSync(path.join(os.tmpdir(), "t3-copilot-mcp-"));
+      try {
+        writeFileSync(
+          path.join(configDir, "mcp-config.json"),
+          JSON.stringify({
+            mcpServers: {
+              "local-badge-repro": {
+                command: "node",
+                args: ["/tmp/t3code-local-mcp-reproduction/dist/index.js"],
+              },
+            },
+          }),
+          "utf8",
+        );
+        mcpClient.createSessionImpl.mockClear();
+
+        const adapter = yield* CopilotAdapter;
+        yield* adapter.startSession({
+          provider: "copilot",
+          threadId: asThreadId("thread-mcp"),
+          runtimeMode: "full-access",
+          providerOptions: {
+            copilot: {
+              configDir,
+            },
+          },
+        });
+
+        const config = mcpClient.createSessionImpl.mock.calls[0]?.[0] as
+          | {
+              configDir?: string;
+              mcpServers?: Record<string, unknown>;
+            }
+          | undefined;
+
+        assert.equal(config?.configDir, configDir);
+        assert.deepStrictEqual(config?.mcpServers, {
+          "local-badge-repro": {
+            type: "local",
+            command: "node",
+            args: ["/tmp/t3code-local-mcp-reproduction/dist/index.js"],
+            tools: ["*"],
+          },
+        });
+      } finally {
+        rmSync(configDir, { recursive: true, force: true });
+      }
+    }),
+  );
+});
+
 afterAll(() => {
   void modeSession.destroy();
   void modeClient.stop();
   void planSession.destroy();
   void planClient.stop();
+  void mcpSession.destroy();
+  void mcpClient.stop();
 });

--- a/apps/server/src/provider/Layers/CopilotAdapter.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.ts
@@ -44,6 +44,7 @@ import {
   recordTurnUsage,
   type CopilotTurnTrackingState,
 } from "./copilotTurnTracking.ts";
+import { loadCopilotMcpServers } from "./copilotMcpServers.ts";
 import { normalizeCopilotCliPathOverride, resolveBundledCopilotCliPath } from "./copilotCliPath.ts";
 import { CopilotAdapter, type CopilotAdapterShape } from "../Services/CopilotAdapter.ts";
 import type {
@@ -1272,6 +1273,16 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
           normalizeCopilotCliPathOverride(input.providerOptions?.copilot?.cliPath) ??
           resolveBundledCopilotCliPath();
         const configDir = trimToUndefined(input.providerOptions?.copilot?.configDir);
+        const mcpServers = yield* Effect.tryPromise({
+          try: () => loadCopilotMcpServers(configDir),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: toMessage(cause, "Failed to load GitHub Copilot MCP configuration."),
+              cause,
+            }),
+        });
         const resumeSessionId = extractResumeSessionId(input.resumeCursor);
         const clientOptions: CopilotClientOptions = {
           ...(cliPath ? { cliPath } : {}),
@@ -1307,6 +1318,7 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
                 ...(reasoningEffort ? { reasoningEffort } : {}),
                 ...(input.cwd ? { workingDirectory: input.cwd } : {}),
                 ...(configDir ? { configDir } : {}),
+                ...(mcpServers ? { mcpServers } : {}),
                 streaming: true,
               });
             }
@@ -1316,6 +1328,7 @@ const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
               ...(reasoningEffort ? { reasoningEffort } : {}),
               ...(input.cwd ? { workingDirectory: input.cwd } : {}),
               ...(configDir ? { configDir } : {}),
+              ...(mcpServers ? { mcpServers } : {}),
               streaming: true,
             });
           },

--- a/apps/server/src/provider/Layers/copilotMcpServers.ts
+++ b/apps/server/src/provider/Layers/copilotMcpServers.ts
@@ -1,0 +1,124 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { MCPServerConfig } from "@github/copilot-sdk";
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.flatMap((item) => {
+    const normalized = asNonEmptyString(item);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function asStringRecord(value: unknown): Record<string, string> | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const entries = Object.entries(record).flatMap(([key, item]) => {
+    const normalized = asNonEmptyString(item);
+    return normalized ? [[key, normalized] as const] : [];
+  });
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function asTimeout(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function normalizeTools(value: unknown): string[] {
+  const tools = asStringArray(value);
+  return tools ?? ["*"];
+}
+
+function toMcpServerConfig(entry: unknown): MCPServerConfig | undefined {
+  const record = asRecord(entry);
+  if (!record) {
+    return undefined;
+  }
+
+  const type = asNonEmptyString(record.type);
+  const command = asNonEmptyString(record.command);
+  const args = asStringArray(record.args) ?? [];
+  const url = asNonEmptyString(record.url);
+  const tools = normalizeTools(record.tools);
+  const timeout = asTimeout(record.timeout);
+  const env = asStringRecord(record.env);
+  const cwd = asNonEmptyString(record.cwd);
+  const headers = asStringRecord(record.headers);
+
+  if (command && (type === undefined || type === "local" || type === "stdio")) {
+    return {
+      type: "local",
+      command,
+      args,
+      tools,
+      ...(env ? { env } : {}),
+      ...(cwd ? { cwd } : {}),
+      ...(timeout !== undefined ? { timeout } : {}),
+    };
+  }
+
+  if (url && (type === undefined || type === "http" || type === "sse")) {
+    return {
+      type: type === "sse" ? "sse" : "http",
+      url,
+      tools,
+      ...(headers ? { headers } : {}),
+      ...(timeout !== undefined ? { timeout } : {}),
+    };
+  }
+
+  return undefined;
+}
+
+export async function loadCopilotMcpServers(
+  configDir: string | undefined,
+): Promise<Record<string, MCPServerConfig> | undefined> {
+  const baseDir = asNonEmptyString(configDir) ?? path.join(os.homedir(), ".copilot");
+  const configPath = path.join(baseDir, "mcp-config.json");
+
+  let raw: string;
+  try {
+    raw = await fsp.readFile(configPath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+
+  const parsed = asRecord(JSON.parse(raw));
+  const servers = asRecord(parsed?.mcpServers);
+  if (!servers) {
+    return undefined;
+  }
+
+  const normalizedEntries = Object.entries(servers).flatMap(([name, value]) => {
+    const normalized = toMcpServerConfig(value);
+    return normalized ? [[name, normalized] as const] : [];
+  });
+
+  return normalizedEntries.length > 0 ? Object.fromEntries(normalizedEntries) : undefined;
+}


### PR DESCRIPTION
This PR enables local stdio and remote MCP servers configured in the GitHub Copilot CLI config (`~/.copilot/mcp-config.json`) to work within t3code by passing the server definitions to the underlying Copilot SDK.

- Added `apps/server/src/provider/Layers/copilotMcpServers.ts` to parse `mcp-config.json`, normalize server entries (local/stdio with `command`/`args` or remote HTTP with `url`/`headers`), and default the `tools` allowlist to `"*"`.
- Updated `apps/server/src/provider/Layers/CopilotAdapter.ts` to load the MCP server map before creating or resuming sessions, resolving the path from the provided `configDir` (or `~/.copilot` by default), and passing it to the SDK via the `mcpServers` session option.
- Added unit tests in `apps/server/src/provider/Layers/CopilotAdapter.test.ts` to verify that a configured local stdio server is correctly transformed and injected into the SDK session config.

<a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/pull/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/task/c4dcba34-eb6b-4fe7-8ff2-815c94185b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-10&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-10"><img alt="TC-10 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-10"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP (Model Context Protocol) server configuration support, enabling integration with local and HTTP/SSE MCP servers
  * MCP server configurations are now automatically loaded and passed to sessions during creation and resumption
  * Includes error handling for configuration loading failures

* **Tests**
  * Added comprehensive tests for MCP configuration loading and session integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->