### PR TITLE
feat: add manual install fallback for unsigned macOS auto-updates

### DIFF
--- a/apps/desktop/src/macCodeSigning.test.ts
+++ b/apps/desktop/src/macCodeSigning.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { hasDeveloperIdApplicationAuthority } from "./macCodeSigning";
+
+describe("hasDeveloperIdApplicationAuthority", () => {
+  it("matches a Developer ID Application authority line", () => {
+    expect(
+      hasDeveloperIdApplicationAuthority(`Executable=/Applications/T3 Code.app/Contents/MacOS/T3 Code
+Identifier=com.t3tools.t3code
+Authority=Developer ID Application: T3 Tools, Inc. (ABCDE12345)
+Authority=Developer ID Certification Authority
+Authority=Apple Root CA`),
+    ).toBe(true);
+  });
+
+  it("ignores ad hoc signatures and unsigned output", () => {
+    expect(
+      hasDeveloperIdApplicationAuthority(`Executable=/Applications/T3 Code.app/Contents/MacOS/T3 Code
+Signature=adhoc`),
+    ).toBe(false);
+    expect(hasDeveloperIdApplicationAuthority("code object is not signed at all")).toBe(false);
+  });
+});

--- a/apps/desktop/src/macCodeSigning.ts
+++ b/apps/desktop/src/macCodeSigning.ts
@@ -1,0 +1,5 @@
+export function hasDeveloperIdApplicationAuthority(value: string): boolean {
+  return value
+    .split(/\r?\n/)
+    .some((line) => line.trim().startsWith("Authority=Developer ID Application:"));
+}

--- a/apps/desktop/src/macUpdateInstaller.test.ts
+++ b/apps/desktop/src/macUpdateInstaller.test.ts
@@ -1,0 +1,62 @@
+import * as FS from "node:fs";
+import * as OS from "node:os";
+import * as Path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildMacManualUpdateInstallScript,
+  findFirstAppBundlePath,
+  resolveDownloadedMacUpdateZipPath,
+} from "./macUpdateInstaller";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    FS.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveDownloadedMacUpdateZipPath", () => {
+  it("returns the downloaded zip path", () => {
+    expect(resolveDownloadedMacUpdateZipPath(["/tmp/update.zip", "/tmp/update.blockmap"])).toBe(
+      "/tmp/update.zip",
+    );
+  });
+
+  it("returns null when no zip exists", () => {
+    expect(resolveDownloadedMacUpdateZipPath(["/tmp/update.blockmap"])).toBeNull();
+  });
+});
+
+describe("findFirstAppBundlePath", () => {
+  it("finds an extracted app bundle recursively", () => {
+    const rootDir = FS.mkdtempSync(Path.join(OS.tmpdir(), "t3-mac-update-"));
+    tempDirs.push(rootDir);
+
+    const appPath = Path.join(rootDir, "nested", "T3 Code.app");
+    FS.mkdirSync(appPath, { recursive: true });
+
+    expect(findFirstAppBundlePath(rootDir)).toBe(appPath);
+  });
+});
+
+describe("buildMacManualUpdateInstallScript", () => {
+  it("builds a detached installer script with admin fallback", () => {
+    const script = buildMacManualUpdateInstallScript({
+      appPid: 123,
+      sourceAppPath: "/tmp/T3 Code's Update.app",
+      targetAppPath: "/Applications/T3 Code.app",
+      stagingDir: "/tmp/t3-stage",
+    });
+
+    expect(script).toContain("APP_PID=123");
+    expect(script).toContain("wait_for_app_exit");
+    expect(script).toContain("/usr/bin/ditto");
+    expect(script).toContain("/usr/bin/osascript");
+    expect(script).toContain(`SOURCE_APP='/tmp/T3 Code'\\''s Update.app'`);
+    expect(script).toContain(`TARGET_APP='/Applications/T3 Code.app'`);
+    expect(script).toContain('/usr/bin/open -n "$TARGET_APP"');
+  });
+});

--- a/apps/desktop/src/macUpdateInstaller.ts
+++ b/apps/desktop/src/macUpdateInstaller.ts
@@ -1,0 +1,89 @@
+import * as FS from "node:fs";
+import * as Path from "node:path";
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+export function resolveDownloadedMacUpdateZipPath(
+  downloadedFiles: ReadonlyArray<string>,
+): string | null {
+  for (const file of downloadedFiles) {
+    if (file.toLowerCase().endsWith(".zip")) {
+      return file;
+    }
+  }
+  return null;
+}
+
+export function findFirstAppBundlePath(rootDir: string): string | null {
+  const queue = [rootDir];
+
+  while (queue.length > 0) {
+    const currentDir = queue.shift();
+    if (!currentDir) {
+      continue;
+    }
+
+    for (const entry of FS.readdirSync(currentDir, { withFileTypes: true })) {
+      const entryPath = Path.join(currentDir, entry.name);
+      if (entry.isDirectory() && entry.name.endsWith(".app")) {
+        return entryPath;
+      }
+      if (entry.isDirectory()) {
+        queue.push(entryPath);
+      }
+    }
+  }
+
+  return null;
+}
+
+export function buildMacManualUpdateInstallScript(args: {
+  appPid: number;
+  sourceAppPath: string;
+  targetAppPath: string;
+  stagingDir: string;
+}): string {
+  const sourceAppPath = shellQuote(args.sourceAppPath);
+  const targetAppPath = shellQuote(args.targetAppPath);
+  const stagingDir = shellQuote(args.stagingDir);
+
+  return `#!/bin/sh
+set -eu
+APP_PID=${args.appPid}
+SOURCE_APP=${sourceAppPath}
+TARGET_APP=${targetAppPath}
+STAGING_DIR=${stagingDir}
+
+cleanup() {
+  /bin/rm -rf "$STAGING_DIR"
+}
+
+trap cleanup EXIT
+
+wait_for_app_exit() {
+  while /bin/kill -0 "$APP_PID" 2>/dev/null; do
+    /bin/sleep 0.2
+  done
+}
+
+install_update() {
+  /bin/rm -rf "$TARGET_APP"
+  /usr/bin/ditto "$SOURCE_APP" "$TARGET_APP"
+}
+
+wait_for_app_exit
+
+if ! install_update >/dev/null 2>&1; then
+  export SOURCE_APP TARGET_APP
+  /usr/bin/osascript <<'APPLESCRIPT'
+set sourceApp to system attribute "SOURCE_APP"
+set targetApp to system attribute "TARGET_APP"
+do shell script "/bin/rm -rf " & quoted form of targetApp & " && /usr/bin/ditto " & quoted form of sourceApp & " " & quoted form of targetApp with administrator privileges
+APPLESCRIPT
+fi
+
+/usr/bin/open -n "$TARGET_APP"
+`;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,6 +29,12 @@ import { NetService } from "@t3tools/shared/Net";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
 import { fixPath } from "./fixPath";
+import { hasDeveloperIdApplicationAuthority } from "./macCodeSigning";
+import {
+  buildMacManualUpdateInstallScript,
+  findFirstAppBundlePath,
+  resolveDownloadedMacUpdateZipPath,
+} from "./macUpdateInstaller";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
 import {
   createInitialDesktopUpdateState,
@@ -93,6 +99,8 @@ let backendLogSink: RotatingFileSink | null = null;
 let restoreStdIoCapture: (() => void) | null = null;
 
 let destructiveMenuIconCache: Electron.NativeImage | null | undefined;
+let macDeveloperIdSigned: boolean | null = null;
+let downloadedUpdateFiles: string[] = [];
 const desktopRuntimeInfo = resolveDesktopRuntimeInfo({
   platform: process.platform,
   processArch: process.arch,
@@ -113,6 +121,48 @@ function sanitizeLogValue(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+function resolveMacAppBundlePath(): string | null {
+  if (process.platform !== "darwin" || !app.isPackaged) {
+    return null;
+  }
+
+  return Path.resolve(process.execPath, "..", "..", "..");
+}
+
+function isMacDeveloperIdSignedBuild(): boolean {
+  if (process.platform !== "darwin" || !app.isPackaged) {
+    return false;
+  }
+  if (macDeveloperIdSigned !== null) {
+    return macDeveloperIdSigned;
+  }
+
+  const appBundlePath = resolveMacAppBundlePath();
+  if (!appBundlePath) {
+    macDeveloperIdSigned = false;
+    return macDeveloperIdSigned;
+  }
+
+  const result = ChildProcess.spawnSync("codesign", ["--display", "--verbose=4", appBundlePath], {
+    encoding: "utf8",
+  });
+  const details = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim();
+  macDeveloperIdSigned = result.status === 0 && hasDeveloperIdApplicationAuthority(details);
+
+  if (!macDeveloperIdSigned) {
+    const diagnostic =
+      result.error?.message ||
+      (result.status === 0
+        ? "missing Developer ID Application authority in code signature"
+        : details || `codesign exited with status ${result.status ?? "unknown"}`);
+    console.info(
+      `[desktop-updater] macOS code-signing check indicates manual install fallback will be used: ${sanitizeLogValue(diagnostic)}`,
+    );
+  }
+
+  return macDeveloperIdSigned;
+}
+
 function writeDesktopLogHeader(message: string): void {
   if (!desktopLogSink) return;
   desktopLogSink.write(`[${logTimestamp()}] [${logScope("desktop")}] ${message}\n`);
@@ -131,6 +181,14 @@ function formatErrorMessage(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+function setDownloadedUpdateFiles(files: ReadonlyArray<string>): void {
+  downloadedUpdateFiles = [...files];
+}
+
+function clearDownloadedUpdateFiles(): void {
+  downloadedUpdateFiles = [];
 }
 
 function getSafeExternalUrl(rawUrl: unknown): string | null {
@@ -513,13 +571,7 @@ function dispatchMenuAction(action: string): void {
 }
 
 function handleCheckForUpdatesMenuClick(): void {
-  const disabledReason = getAutoUpdateDisabledReason({
-    isDevelopment,
-    isPackaged: app.isPackaged,
-    platform: process.platform,
-    appImage: process.env.APPIMAGE,
-    disabledByEnv: process.env.T3CODE_DISABLE_AUTO_UPDATE === "1",
-  });
+  const disabledReason = resolveAutoUpdateDisabledReason();
   if (disabledReason) {
     console.info("[desktop-updater] Manual update check requested, but updates are disabled.");
     void dialog.showMessageBox({
@@ -730,16 +782,14 @@ function setUpdateState(patch: Partial<DesktopUpdateState>): void {
   emitUpdateState();
 }
 
-function shouldEnableAutoUpdates(): boolean {
-  return (
-    getAutoUpdateDisabledReason({
-      isDevelopment,
-      isPackaged: app.isPackaged,
-      platform: process.platform,
-      appImage: process.env.APPIMAGE,
-      disabledByEnv: process.env.T3CODE_DISABLE_AUTO_UPDATE === "1",
-    }) === null
-  );
+function resolveAutoUpdateDisabledReason(): string | null {
+  return getAutoUpdateDisabledReason({
+    isDevelopment,
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+    appImage: process.env.APPIMAGE,
+    disabledByEnv: process.env.T3CODE_DISABLE_AUTO_UPDATE === "1",
+  });
 }
 
 async function checkForUpdates(reason: string): Promise<void> {
@@ -777,16 +827,66 @@ async function downloadAvailableUpdate(): Promise<{ accepted: boolean; completed
   console.info("[desktop-updater] Downloading update...");
 
   try {
-    await autoUpdater.downloadUpdate();
+    const downloadedFiles = await autoUpdater.downloadUpdate();
+    setDownloadedUpdateFiles(downloadedFiles);
     return { accepted: true, completed: true };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
+    clearDownloadedUpdateFiles();
     setUpdateState(reduceDesktopUpdateStateOnDownloadFailure(updateState, message));
     console.error(`[desktop-updater] Failed to download update: ${message}`);
     return { accepted: true, completed: false };
   } finally {
     updateDownloadInFlight = false;
   }
+}
+
+function installDownloadedUnsignedMacUpdate(): void {
+  const currentAppPath = resolveMacAppBundlePath();
+  if (!currentAppPath) {
+    throw new Error("Could not resolve the current app bundle path.");
+  }
+
+  const downloadedZipPath = resolveDownloadedMacUpdateZipPath(downloadedUpdateFiles);
+  if (!downloadedZipPath) {
+    throw new Error("Could not locate the downloaded macOS update archive.");
+  }
+
+  const stagingDir = FS.mkdtempSync(Path.join(OS.tmpdir(), "t3-mac-update-"));
+  const extractedDir = Path.join(stagingDir, "extracted");
+  FS.mkdirSync(extractedDir, { recursive: true });
+
+  const unzipResult = ChildProcess.spawnSync(
+    "ditto",
+    ["-x", "-k", downloadedZipPath, extractedDir],
+    {
+      encoding: "utf8",
+    },
+  );
+  if (unzipResult.status !== 0) {
+    const details = `${unzipResult.stdout ?? ""}\n${unzipResult.stderr ?? ""}`.trim();
+    throw new Error(details || `ditto exited with status ${unzipResult.status ?? "unknown"}`);
+  }
+
+  const extractedAppPath = findFirstAppBundlePath(extractedDir);
+  if (!extractedAppPath) {
+    throw new Error("Could not find the extracted app bundle inside the downloaded update.");
+  }
+
+  const installerScriptPath = Path.join(stagingDir, "install-update.sh");
+  const installerScript = buildMacManualUpdateInstallScript({
+    appPid: process.pid,
+    sourceAppPath: extractedAppPath,
+    targetAppPath: currentAppPath,
+    stagingDir,
+  });
+  FS.writeFileSync(installerScriptPath, installerScript, { mode: 0o700 });
+
+  const installerProcess = ChildProcess.spawn("/bin/sh", [installerScriptPath], {
+    detached: true,
+    stdio: "ignore",
+  });
+  installerProcess.unref();
 }
 
 async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed: boolean }> {
@@ -798,7 +898,12 @@ async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed
   clearUpdatePollTimer();
   try {
     await stopBackendAndWaitForExit();
-    autoUpdater.quitAndInstall();
+    if (process.platform === "darwin" && !isMacDeveloperIdSignedBuild()) {
+      installDownloadedUnsignedMacUpdate();
+      app.quit();
+    } else {
+      autoUpdater.quitAndInstall();
+    }
     return { accepted: true, completed: true };
   } catch (error: unknown) {
     const message = formatErrorMessage(error);
@@ -810,13 +915,15 @@ async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed
 }
 
 function configureAutoUpdater(): void {
-  const enabled = shouldEnableAutoUpdates();
+  const disabledReason = resolveAutoUpdateDisabledReason();
+  const enabled = disabledReason === null;
   setUpdateState({
     ...createInitialDesktopUpdateState(app.getVersion(), desktopRuntimeInfo),
     enabled,
     status: enabled ? "idle" : "disabled",
   });
   if (!enabled) {
+    console.info(`[desktop-updater] Automatic updates disabled: ${disabledReason}`);
     return;
   }
   updaterConfigured = true;
@@ -857,6 +964,7 @@ function configureAutoUpdater(): void {
     console.info("[desktop-updater] Looking for updates...");
   });
   autoUpdater.on("update-available", (info) => {
+    clearDownloadedUpdateFiles();
     setUpdateState(
       reduceDesktopUpdateStateOnUpdateAvailable(
         updateState,
@@ -868,6 +976,7 @@ function configureAutoUpdater(): void {
     console.info(`[desktop-updater] Update available: ${info.version}`);
   });
   autoUpdater.on("update-not-available", () => {
+    clearDownloadedUpdateFiles();
     setUpdateState(reduceDesktopUpdateStateOnNoUpdate(updateState, new Date().toISOString()));
     lastLoggedDownloadMilestone = -1;
     console.info("[desktop-updater] No updates available.");


### PR DESCRIPTION
## What Changed

- Added `isMacDeveloperIdSignedBuild()` in `apps/desktop/src/main.ts` to detect Developer ID signing at runtime using `codesign` and cache the result.
- Created `apps/desktop/src/macCodeSigning.ts` with `hasDeveloperIdApplicationAuthority()` to parse code-sign output and verify Developer ID authority.
- Created `apps/desktop/src/macUpdateInstaller.ts` with:
  - `buildMacManualUpdateInstallScript()` to generate a detached installer shell script that waits for app exit, replaces the bundle via `ditto`, prompts for admin if needed, and relaunches.
  - `findFirstAppBundlePath()` to recursively find an `.app` bundle in the extracted update directory.
  - `resolveDownloadedMacUpdateZipPath()` to locate the downloaded update `.zip` from electron-updater's file list.
- Modified `installDownloadedUpdate()` in `apps/desktop/src/main.ts` to branch at install time: signed builds continue using `autoUpdater.quitAndInstall()`, while unsigned builds use the new manual fallback path.
- Added `setDownloadedUpdateFiles()` and `clearDownloadedUpdateFiles()` to retain downloaded file paths for manual install.
- Removed the macOS signing gate from `getAutoUpdateDisabledReason()` in `apps/desktop/src/updateState.ts` so updates remain enabled for unsigned builds.
- Added tests in `apps/desktop/src/macCodeSigning.test.ts` and `apps/desktop/src/macUpdateInstaller.test.ts`.

## Why

Electron's `autoUpdater.quitAndInstall()` on macOS uses Squirrel.Mac, which requires a signed Developer ID application to install without blocking. Unsigned DMG installs (e.g., local test builds opened via Gatekeeper's "Open Anyway") would download updates but fail silently when clicked to install, providing no restart or installation feedback. This PR provides a working update flow for unsigned builds by extracting the downloaded `.zip` and replacing the app bundle via `ditto` from a detached installer script, preserving the signed-build behavior using the native Squirrel path.

## UI Changes

None (backend updater behavior only).

<a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/pull/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/task/fe53d984-ec05-4711-b745-1f892f818331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-9&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-9"><img alt="TC-9 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-9"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added macOS code-signing verification for desktop application.
  * Implemented manual update installation fallback for unsigned macOS builds.

* **Tests**
  * Added comprehensive test coverage for macOS code-signing detection and update installation utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->