### PR TITLE
fix: show previous toolcalls when composing new chat message in thread

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,5 +1,31 @@
+import { EventId, TurnId, type OrchestrationThreadActivity } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
-import { resolveProviderHealthBannerProvider } from "./ChatView.logic";
+import {
+  deriveVisibleThreadWorkLogEntries,
+  resolveProviderHealthBannerProvider,
+} from "./ChatView.logic";
+
+function makeActivity(overrides: {
+  id?: string;
+  createdAt?: string;
+  kind?: string;
+  summary?: string;
+  tone?: OrchestrationThreadActivity["tone"];
+  payload?: Record<string, unknown>;
+  turnId?: string;
+  sequence?: number;
+}): OrchestrationThreadActivity {
+  return {
+    id: EventId.makeUnsafe(overrides.id ?? crypto.randomUUID()),
+    createdAt: overrides.createdAt ?? "2026-02-23T00:00:00.000Z",
+    kind: overrides.kind ?? "tool.started",
+    summary: overrides.summary ?? "Tool call",
+    tone: overrides.tone ?? "tool",
+    payload: overrides.payload ?? {},
+    turnId: overrides.turnId ? TurnId.makeUnsafe(overrides.turnId) : null,
+    ...(overrides.sequence !== undefined ? { sequence: overrides.sequence } : {}),
+  };
+}
 
 describe("resolveProviderHealthBannerProvider", () => {
   it("uses the active session provider when a session exists", () => {
@@ -18,5 +44,31 @@ describe("resolveProviderHealthBannerProvider", () => {
         selectedProvider: "copilot",
       }),
     ).toBe("copilot");
+  });
+});
+
+describe("deriveVisibleThreadWorkLogEntries", () => {
+  it("keeps completed tool calls from previous turns visible in the thread timeline", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tool-1",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        turnId: "turn-1",
+        kind: "tool.completed",
+        summary: "First tool call",
+      }),
+      makeActivity({
+        id: "tool-2",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        turnId: "turn-2",
+        kind: "tool.completed",
+        summary: "Second tool call",
+      }),
+    ];
+
+    expect(deriveVisibleThreadWorkLogEntries(activities).map((entry) => entry.id)).toEqual([
+      "tool-1",
+      "tool-2",
+    ]);
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,9 +1,15 @@
-import { ProjectId, type ProviderKind, type ThreadId } from "@t3tools/contracts";
+import {
+  ProjectId,
+  type OrchestrationThreadActivity,
+  type ProviderKind,
+  type ThreadId,
+} from "@t3tools/contracts";
 import { type ChatMessage, type Thread } from "../types";
 import { randomUUID } from "~/lib/utils";
 import { getAppModelOptions } from "../appSettings";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import { Schema } from "effect";
+import { deriveWorkLogEntries, type WorkLogEntry } from "../session-logic";
 
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
 const WORKTREE_BRANCH_PREFIX = "t3code";
@@ -131,4 +137,10 @@ export function resolveProviderHealthBannerProvider(input: {
   selectedProvider: ProviderKind;
 }): ProviderKind {
   return input.sessionProvider ?? input.selectedProvider;
+}
+
+export function deriveVisibleThreadWorkLogEntries(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): WorkLogEntry[] {
+  return deriveWorkLogEntries(activities, undefined);
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -80,7 +80,6 @@ import {
   type PendingUserInput,
   type ProviderPickerKind,
   PROVIDER_OPTIONS,
-  deriveWorkLogEntries,
   hasToolActivityForTurn,
   isLatestTurnSettled,
   formatElapsed,
@@ -249,7 +248,10 @@ import {
   computeMessageDurationStart,
   normalizeCompactToolLabel,
 } from "./chat/MessagesTimeline.logic";
-import { resolveProviderHealthBannerProvider } from "./ChatView.logic";
+import {
+  deriveVisibleThreadWorkLogEntries,
+  resolveProviderHealthBannerProvider,
+} from "./ChatView.logic";
 
 function formatMessageMeta(
   createdAt: string,
@@ -1526,8 +1528,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
   const workLogEntries = useMemo(
-    () => deriveWorkLogEntries(threadActivities, activeLatestTurn?.turnId ?? undefined),
-    [activeLatestTurn?.turnId, threadActivities],
+    () => deriveVisibleThreadWorkLogEntries(threadActivities),
+    [threadActivities],
   );
   const latestTurnHasToolActivity = useMemo(
     () => hasToolActivityForTurn(threadActivities, activeLatestTurn?.turnId),


### PR DESCRIPTION
This PR fixes an issue where previous tool calls disappeared from the thread timeline after starting a new chat message. The timeline was deriving work log entries filtered to only the latest turn, causing prior tool activity to be hidden when the user began composing a new turn.

- Added `deriveVisibleThreadWorkLogEntries()` in `apps/web/src/components/ChatView.logic.ts` to derive work entries from all thread activities regardless of turn
- Updated `apps/web/src/components/ChatView.tsx` to use `deriveVisibleThreadWorkLogEntries()` for timeline rendering
- Added regression test in `apps/web/src/components/ChatView.logic.test.ts` verifying completed tool calls from previous turns remain visible in the timeline

<a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/pull/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/task/9877c0b1-7508-439b-86f4-c3a7d6edd8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-11&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-11"><img alt="TC-11 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-11"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal structure for handling thread work log entry visibility

* **Tests**
  * Added test coverage for thread work log entry handling in chat view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->