### PR TITLE
fix: incorrect hammer icons for work log tool calls

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -247,6 +247,8 @@ import { formatTimestamp } from "../timestampFormat";
 import {
   computeMessageDurationStart,
   normalizeCompactToolLabel,
+  resolveWorkEntryIconKind,
+  type WorkEntryIconKind,
 } from "./chat/MessagesTimeline.logic";
 import {
   deriveVisibleThreadWorkLogEntries,
@@ -373,70 +375,46 @@ function workEntryPreview(workEntry: {
 }
 
 function workEntryIcon(workEntry: WorkLogEntry): LucideIcon {
-  if (workEntry.requestKind === "command") return TerminalIcon;
-  if (workEntry.requestKind === "file-read") return EyeIcon;
-  if (workEntry.requestKind === "file-change") return SquarePenIcon;
-
-  if (workEntry.itemType === "command_execution" || workEntry.command) {
-    return TerminalIcon;
+  const iconKind = resolveWorkEntryIconKind(workEntry);
+  if (!iconKind) {
+    return workToneIcon(workEntry.tone).icon;
   }
-  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
-    return SquarePenIcon;
-  }
-  if (workEntry.itemType === "web_search") return GlobeIcon;
-  if (workEntry.itemType === "image_view") return EyeIcon;
+  return iconKindToLucideIcon(iconKind);
+}
 
-  switch (workEntry.itemType) {
-    case "mcp_tool_call":
-      return WrenchIcon;
-    case "dynamic_tool_call":
-    case "collab_agent_tool_call":
+function iconKindToLucideIcon(iconKind: WorkEntryIconKind): LucideIcon {
+  switch (iconKind) {
+    case "bot":
+      return BotIcon;
+    case "check":
+      return CheckIcon;
+    case "database":
+      return DatabaseIcon;
+    case "eye":
+      return EyeIcon;
+    case "file":
+      return FileIcon;
+    case "folder":
+      return FolderIcon;
+    case "globe":
+      return GlobeIcon;
+    case "hammer":
       return HammerIcon;
+    case "list-todo":
+      return ListTodoIcon;
+    case "search":
+      return SearchIcon;
+    case "square-pen":
+      return SquarePenIcon;
+    case "target":
+      return TargetIcon;
+    case "terminal":
+      return TerminalIcon;
+    case "wrench":
+      return WrenchIcon;
+    case "zap":
+      return ZapIcon;
   }
-
-  const haystack = [
-    workEntry.label,
-    workEntry.toolTitle,
-    workEntry.detail,
-    workEntry.output,
-    workEntry.command,
-  ]
-    .filter((value): value is string => typeof value === "string" && value.length > 0)
-    .join(" ")
-    .toLowerCase();
-
-  if (haystack.includes("report_intent") || haystack.includes("intent logged")) {
-    return TargetIcon;
-  }
-  if (
-    haystack.includes("bash") ||
-    haystack.includes("read_bash") ||
-    haystack.includes("write_bash") ||
-    haystack.includes("stop_bash") ||
-    haystack.includes("list_bash")
-  ) {
-    return TerminalIcon;
-  }
-  if (haystack.includes("sql")) return DatabaseIcon;
-  if (haystack.includes("view")) return EyeIcon;
-  if (haystack.includes("apply_patch")) return SquarePenIcon;
-  if (haystack.includes("rg") || haystack.includes("glob") || haystack.includes("search")) {
-    return SearchIcon;
-  }
-  if (haystack.includes("skill")) return ZapIcon;
-  if (haystack.includes("ask_user") || haystack.includes("approval")) return BotIcon;
-  if (haystack.includes("store_memory")) return FolderIcon;
-  if (haystack.includes("edit") || haystack.includes("patch")) return WrenchIcon;
-  if (haystack.includes("file")) return FileIcon;
-
-  if (haystack.includes("task")) return HammerIcon;
-
-  if (workEntry.activityKind === "turn.plan.updated") return ListTodoIcon;
-  if (workEntry.activityKind === "task.progress") return HammerIcon;
-  if (workEntry.activityKind === "approval.requested") return BotIcon;
-  if (workEntry.activityKind === "approval.resolved") return CheckIcon;
-
-  return workToneIcon(workEntry.tone).icon;
 }
 
 function capitalizePhrase(value: string): string {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { computeMessageDurationStart, normalizeCompactToolLabel } from "./MessagesTimeline.logic";
+import {
+  computeMessageDurationStart,
+  normalizeCompactToolLabel,
+  resolveWorkEntryIconKind,
+} from "./MessagesTimeline.logic";
 
 describe("computeMessageDurationStart", () => {
   it("returns message createdAt when there is no preceding user message", () => {
@@ -141,5 +145,45 @@ describe("normalizeCompactToolLabel", () => {
 
   it("removes trailing completion wording from other labels", () => {
     expect(normalizeCompactToolLabel("Read file completed")).toBe("Read file");
+  });
+});
+
+describe("resolveWorkEntryIconKind", () => {
+  it("prefers search heuristics before generic dynamic tool call fallbacks", () => {
+    expect(
+      resolveWorkEntryIconKind({
+        label: "Context7-resolve-library-id",
+        detail: "Available Libraries: Next.js",
+        itemType: "dynamic_tool_call",
+      }),
+    ).toBe("search");
+  });
+
+  it("keeps sql tools on a database icon", () => {
+    expect(
+      resolveWorkEntryIconKind({
+        label: "Sql",
+        detail: "1 row(s) returned",
+        itemType: "dynamic_tool_call",
+      }),
+    ).toBe("database");
+  });
+
+  it("falls back to hammer for generic dynamic tool calls", () => {
+    expect(
+      resolveWorkEntryIconKind({
+        label: "Tool call",
+        itemType: "dynamic_tool_call",
+      }),
+    ).toBe("hammer");
+  });
+
+  it("keeps mcp tool calls on a wrench when no stronger heuristic matches", () => {
+    expect(
+      resolveWorkEntryIconKind({
+        label: "Tool call",
+        itemType: "mcp_tool_call",
+      }),
+    ).toBe("wrench");
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -5,6 +5,43 @@ export interface TimelineDurationMessage {
   completedAt?: string | undefined;
 }
 
+export type WorkEntryIconKind =
+  | "bot"
+  | "check"
+  | "database"
+  | "eye"
+  | "file"
+  | "folder"
+  | "globe"
+  | "hammer"
+  | "list-todo"
+  | "search"
+  | "square-pen"
+  | "target"
+  | "terminal"
+  | "wrench"
+  | "zap";
+
+export interface WorkEntryIconSource {
+  label: string;
+  toolTitle?: string | undefined;
+  detail?: string | undefined;
+  output?: string | undefined;
+  command?: string | undefined;
+  changedFiles?: ReadonlyArray<string> | undefined;
+  itemType?:
+    | "command_execution"
+    | "file_change"
+    | "mcp_tool_call"
+    | "dynamic_tool_call"
+    | "collab_agent_tool_call"
+    | "web_search"
+    | "image_view"
+    | undefined;
+  requestKind?: "command" | "file-read" | "file-change" | undefined;
+  activityKind?: string | undefined;
+}
+
 export function computeMessageDurationStart(
   messages: ReadonlyArray<TimelineDurationMessage>,
 ): Map<string, string> {
@@ -26,4 +63,75 @@ export function computeMessageDurationStart(
 
 export function normalizeCompactToolLabel(value: string): string {
   return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
+}
+
+export function resolveWorkEntryIconKind(workEntry: WorkEntryIconSource): WorkEntryIconKind | null {
+  if (workEntry.requestKind === "command") return "terminal";
+  if (workEntry.requestKind === "file-read") return "eye";
+  if (workEntry.requestKind === "file-change") return "square-pen";
+
+  if (workEntry.itemType === "command_execution" || workEntry.command) {
+    return "terminal";
+  }
+  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
+    return "square-pen";
+  }
+  if (workEntry.itemType === "web_search") return "globe";
+  if (workEntry.itemType === "image_view") return "eye";
+
+  const haystack = [
+    workEntry.label,
+    workEntry.toolTitle,
+    workEntry.detail,
+    workEntry.output,
+    workEntry.command,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join(" ")
+    .toLowerCase();
+
+  if (haystack.includes("report_intent") || haystack.includes("intent logged")) {
+    return "target";
+  }
+  if (
+    haystack.includes("bash") ||
+    haystack.includes("read_bash") ||
+    haystack.includes("write_bash") ||
+    haystack.includes("stop_bash") ||
+    haystack.includes("list_bash")
+  ) {
+    return "terminal";
+  }
+  if (haystack.includes("sql")) return "database";
+  if (
+    haystack.includes("context7") ||
+    haystack.includes("resolve-library-id") ||
+    haystack.includes("search")
+  ) {
+    return "search";
+  }
+  if (haystack.includes("view")) return "eye";
+  if (haystack.includes("apply_patch")) return "square-pen";
+  if (haystack.includes("skill")) return "zap";
+  if (haystack.includes("ask_user") || haystack.includes("approval")) return "bot";
+  if (haystack.includes("store_memory")) return "folder";
+  if (haystack.includes("edit") || haystack.includes("patch")) return "wrench";
+  if (haystack.includes("file")) return "file";
+
+  if (haystack.includes("task")) return "hammer";
+
+  if (workEntry.activityKind === "turn.plan.updated") return "list-todo";
+  if (workEntry.activityKind === "task.progress") return "hammer";
+  if (workEntry.activityKind === "approval.requested") return "bot";
+  if (workEntry.activityKind === "approval.resolved") return "check";
+
+  if (workEntry.itemType === "mcp_tool_call") return "wrench";
+  if (
+    workEntry.itemType === "dynamic_tool_call" ||
+    workEntry.itemType === "collab_agent_tool_call"
+  ) {
+    return "hammer";
+  }
+
+  return null;
 }

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -14,11 +14,17 @@ import {
   BotIcon,
   CheckIcon,
   CircleAlertIcon,
+  DatabaseIcon,
   EyeIcon,
+  FileIcon,
+  FolderIcon,
   GlobeIcon,
   HammerIcon,
   type LucideIcon,
+  ListTodoIcon,
+  SearchIcon,
   SquarePenIcon,
+  TargetIcon,
   TerminalIcon,
   Undo2Icon,
   WrenchIcon,
@@ -32,7 +38,12 @@ import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesTree } from "./ChangedFilesTree";
 import { DiffStatLabel, hasNonZeroStat } from "./DiffStatLabel";
 import { MessageCopyButton } from "./MessageCopyButton";
-import { computeMessageDurationStart, normalizeCompactToolLabel } from "./MessagesTimeline.logic";
+import {
+  computeMessageDurationStart,
+  normalizeCompactToolLabel,
+  resolveWorkEntryIconKind,
+  type WorkEntryIconKind,
+} from "./MessagesTimeline.logic";
 import { cn } from "~/lib/utils";
 import { type TimestampFormat } from "../../appSettings";
 import { formatTimestamp } from "../../timestampFormat";
@@ -685,28 +696,46 @@ function workEntryPreview(
 }
 
 function workEntryIcon(workEntry: TimelineWorkEntry): LucideIcon {
-  if (workEntry.requestKind === "command") return TerminalIcon;
-  if (workEntry.requestKind === "file-read") return EyeIcon;
-  if (workEntry.requestKind === "file-change") return SquarePenIcon;
-
-  if (workEntry.itemType === "command_execution" || workEntry.command) {
-    return TerminalIcon;
+  const iconKind = resolveWorkEntryIconKind(workEntry);
+  if (!iconKind) {
+    return workToneIcon(workEntry.tone).icon;
   }
-  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
-    return SquarePenIcon;
-  }
-  if (workEntry.itemType === "web_search") return GlobeIcon;
-  if (workEntry.itemType === "image_view") return EyeIcon;
+  return iconKindToLucideIcon(iconKind);
+}
 
-  switch (workEntry.itemType) {
-    case "mcp_tool_call":
-      return WrenchIcon;
-    case "dynamic_tool_call":
-    case "collab_agent_tool_call":
+function iconKindToLucideIcon(iconKind: WorkEntryIconKind): LucideIcon {
+  switch (iconKind) {
+    case "bot":
+      return BotIcon;
+    case "check":
+      return CheckIcon;
+    case "database":
+      return DatabaseIcon;
+    case "eye":
+      return EyeIcon;
+    case "file":
+      return FileIcon;
+    case "folder":
+      return FolderIcon;
+    case "globe":
+      return GlobeIcon;
+    case "hammer":
       return HammerIcon;
+    case "list-todo":
+      return ListTodoIcon;
+    case "search":
+      return SearchIcon;
+    case "square-pen":
+      return SquarePenIcon;
+    case "target":
+      return TargetIcon;
+    case "terminal":
+      return TerminalIcon;
+    case "wrench":
+      return WrenchIcon;
+    case "zap":
+      return ZapIcon;
   }
-
-  return workToneIcon(workEntry.tone).icon;
 }
 
 function capitalizePhrase(value: string): string {


### PR DESCRIPTION
This PR fixes a bug where all tool call icons in the timeline were displaying as hammers. The icon resolution logic was directly mapping `dynamic_tool_call`/`collab_agent_tool_call` itemTypes to `HammerIcon` without considering content-based heuristics, so Context7/SQL/search-style tools all collapsed to hammer icons.

- Added `resolveWorkEntryIconKind()` in `apps/web/src/components/chat/MessagesTimeline.logic.ts` to centralize icon classification based on `requestKind`, `itemType`, and label/detail heuristics before falling back to generic tool icons
- Added heuristics to detect `context7`/`resolve-library-id`/`search` → search icon, `sql` → database icon, while keeping hammer/wrench for generic dynamic/MCP tool calls
- Updated `apps/web/src/components/chat/MessagesTimeline.tsx` to use the shared resolver via `iconKindToLucideIcon()`
- Updated the duplicated legacy resolver in `apps/web/src/components/ChatView.tsx` to use the same shared logic, keeping both timeline views consistent
- Added regression tests in `apps/web/src/components/chat/MessagesTimeline.logic.test.ts` for Context7/search, SQL, generic dynamic tool, and MCP tool icon selection

<a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/pull/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/task/b562c5e8-758c-4853-9057-724898be84fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-12&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-12"><img alt="TC-12 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-12"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized icon resolution logic for work entry display to improve code organization and maintainability. Icon appearance and behavior remain unchanged.

* **Tests**
  * Added comprehensive test coverage for icon resolution with multiple scenarios including search heuristics, database tools, and MCP tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->