### PR TITLE
fix: use appropriate icons for dynamic tool calls instead of hammer fallback

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -141,25 +141,17 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   CircleAlertIcon,
-  DatabaseIcon,
-  EyeIcon,
   FileIcon,
   FolderIcon,
   DiffIcon,
   EllipsisIcon,
   FolderClosedIcon,
-  GlobeIcon,
-  HammerIcon,
   ListTodoIcon,
   LockIcon,
   LockOpenIcon,
   type LucideIcon,
-  SearchIcon,
-  SquarePenIcon,
   TerminalIcon,
-  TargetIcon,
   Undo2Icon,
-  WrenchIcon,
   XIcon,
   CopyIcon,
   CheckIcon,
@@ -247,6 +239,7 @@ import { formatTimestamp } from "../timestampFormat";
 import {
   computeMessageDurationStart,
   normalizeCompactToolLabel,
+  resolveWorkEntryIcon,
 } from "./chat/MessagesTimeline.logic";
 import {
   deriveVisibleThreadWorkLogEntries,
@@ -373,70 +366,7 @@ function workEntryPreview(workEntry: {
 }
 
 function workEntryIcon(workEntry: WorkLogEntry): LucideIcon {
-  if (workEntry.requestKind === "command") return TerminalIcon;
-  if (workEntry.requestKind === "file-read") return EyeIcon;
-  if (workEntry.requestKind === "file-change") return SquarePenIcon;
-
-  if (workEntry.itemType === "command_execution" || workEntry.command) {
-    return TerminalIcon;
-  }
-  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
-    return SquarePenIcon;
-  }
-  if (workEntry.itemType === "web_search") return GlobeIcon;
-  if (workEntry.itemType === "image_view") return EyeIcon;
-
-  switch (workEntry.itemType) {
-    case "mcp_tool_call":
-      return WrenchIcon;
-    case "dynamic_tool_call":
-    case "collab_agent_tool_call":
-      return HammerIcon;
-  }
-
-  const haystack = [
-    workEntry.label,
-    workEntry.toolTitle,
-    workEntry.detail,
-    workEntry.output,
-    workEntry.command,
-  ]
-    .filter((value): value is string => typeof value === "string" && value.length > 0)
-    .join(" ")
-    .toLowerCase();
-
-  if (haystack.includes("report_intent") || haystack.includes("intent logged")) {
-    return TargetIcon;
-  }
-  if (
-    haystack.includes("bash") ||
-    haystack.includes("read_bash") ||
-    haystack.includes("write_bash") ||
-    haystack.includes("stop_bash") ||
-    haystack.includes("list_bash")
-  ) {
-    return TerminalIcon;
-  }
-  if (haystack.includes("sql")) return DatabaseIcon;
-  if (haystack.includes("view")) return EyeIcon;
-  if (haystack.includes("apply_patch")) return SquarePenIcon;
-  if (haystack.includes("rg") || haystack.includes("glob") || haystack.includes("search")) {
-    return SearchIcon;
-  }
-  if (haystack.includes("skill")) return ZapIcon;
-  if (haystack.includes("ask_user") || haystack.includes("approval")) return BotIcon;
-  if (haystack.includes("store_memory")) return FolderIcon;
-  if (haystack.includes("edit") || haystack.includes("patch")) return WrenchIcon;
-  if (haystack.includes("file")) return FileIcon;
-
-  if (haystack.includes("task")) return HammerIcon;
-
-  if (workEntry.activityKind === "turn.plan.updated") return ListTodoIcon;
-  if (workEntry.activityKind === "task.progress") return HammerIcon;
-  if (workEntry.activityKind === "approval.requested") return BotIcon;
-  if (workEntry.activityKind === "approval.resolved") return CheckIcon;
-
-  return workToneIcon(workEntry.tone).icon;
+  return resolveWorkEntryIcon(workEntry);
 }
 
 function capitalizePhrase(value: string): string {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { computeMessageDurationStart, normalizeCompactToolLabel } from "./MessagesTimeline.logic";
+import { BotIcon, HammerIcon, SearchIcon, TerminalIcon, WrenchIcon } from "lucide-react";
+import {
+  computeMessageDurationStart,
+  normalizeCompactToolLabel,
+  resolveWorkEntryIcon,
+} from "./MessagesTimeline.logic";
 
 describe("computeMessageDurationStart", () => {
   it("returns message createdAt when there is no preceding user message", () => {
@@ -141,5 +146,55 @@ describe("normalizeCompactToolLabel", () => {
 
   it("removes trailing completion wording from other labels", () => {
     expect(normalizeCompactToolLabel("Read file completed")).toBe("Read file");
+  });
+});
+
+describe("resolveWorkEntryIcon", () => {
+  it("uses the tool name for dynamic bash calls", () => {
+    expect(
+      resolveWorkEntryIcon({
+        tone: "tool",
+        itemType: "dynamic_tool_call",
+        toolTitle: "bash",
+      }),
+    ).toBe(TerminalIcon);
+  });
+
+  it("uses search styling for dynamic search tools", () => {
+    expect(
+      resolveWorkEntryIcon({
+        tone: "tool",
+        itemType: "dynamic_tool_call",
+        detail: "rg TODO src",
+      }),
+    ).toBe(SearchIcon);
+  });
+
+  it("falls back to a generic tool icon for dynamic tools", () => {
+    expect(
+      resolveWorkEntryIcon({
+        tone: "tool",
+        itemType: "dynamic_tool_call",
+        toolTitle: "custom helper",
+      }),
+    ).toBe(WrenchIcon);
+  });
+
+  it("uses a bot fallback for collab agent calls", () => {
+    expect(
+      resolveWorkEntryIcon({
+        tone: "tool",
+        itemType: "collab_agent_tool_call",
+      }),
+    ).toBe(BotIcon);
+  });
+
+  it("keeps task progress on the hammer icon", () => {
+    expect(
+      resolveWorkEntryIcon({
+        tone: "tool",
+        activityKind: "task.progress",
+      }),
+    ).toBe(HammerIcon);
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -1,3 +1,22 @@
+import {
+  BotIcon,
+  CheckIcon,
+  DatabaseIcon,
+  EyeIcon,
+  FileIcon,
+  FolderIcon,
+  GlobeIcon,
+  HammerIcon,
+  type LucideIcon,
+  ListTodoIcon,
+  SearchIcon,
+  SquarePenIcon,
+  TargetIcon,
+  TerminalIcon,
+  WrenchIcon,
+  ZapIcon,
+} from "lucide-react";
+
 export interface TimelineDurationMessage {
   id: string;
   role: "user" | "assistant" | "system";
@@ -26,4 +45,85 @@ export function computeMessageDurationStart(
 
 export function normalizeCompactToolLabel(value: string): string {
   return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
+}
+
+export interface WorkEntryIconInput {
+  tone: "thinking" | "tool" | "info" | "error";
+  activityKind?: string;
+  itemType?:
+    | "command_execution"
+    | "file_change"
+    | "mcp_tool_call"
+    | "dynamic_tool_call"
+    | "collab_agent_tool_call"
+    | "web_search"
+    | "image_view";
+  requestKind?: "command" | "file-read" | "file-change";
+  label?: string;
+  toolTitle?: string;
+  detail?: string;
+  output?: string;
+  command?: string;
+  changedFiles?: ReadonlyArray<string>;
+}
+
+export function resolveWorkEntryIcon(workEntry: WorkEntryIconInput): LucideIcon {
+  if (workEntry.requestKind === "command") return TerminalIcon;
+  if (workEntry.requestKind === "file-read") return EyeIcon;
+  if (workEntry.requestKind === "file-change") return SquarePenIcon;
+
+  if (workEntry.itemType === "command_execution" || workEntry.command) {
+    return TerminalIcon;
+  }
+  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
+    return SquarePenIcon;
+  }
+  if (workEntry.itemType === "web_search") return GlobeIcon;
+  if (workEntry.itemType === "image_view") return EyeIcon;
+  if (workEntry.itemType === "mcp_tool_call") return WrenchIcon;
+
+  const haystack = [
+    workEntry.label,
+    workEntry.toolTitle,
+    workEntry.detail,
+    workEntry.output,
+    workEntry.command,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join(" ")
+    .toLowerCase();
+
+  if (haystack.includes("report_intent") || haystack.includes("intent logged")) {
+    return TargetIcon;
+  }
+  if (
+    haystack.includes("bash") ||
+    haystack.includes("read_bash") ||
+    haystack.includes("write_bash") ||
+    haystack.includes("stop_bash") ||
+    haystack.includes("list_bash")
+  ) {
+    return TerminalIcon;
+  }
+  if (haystack.includes("sql")) return DatabaseIcon;
+  if (haystack.includes("view")) return EyeIcon;
+  if (haystack.includes("apply_patch")) return SquarePenIcon;
+  if (haystack.includes("rg") || haystack.includes("glob") || haystack.includes("search")) {
+    return SearchIcon;
+  }
+  if (haystack.includes("skill")) return ZapIcon;
+  if (haystack.includes("ask_user") || haystack.includes("approval")) return BotIcon;
+  if (haystack.includes("store_memory")) return FolderIcon;
+  if (haystack.includes("edit") || haystack.includes("patch")) return WrenchIcon;
+  if (haystack.includes("file")) return FileIcon;
+  if (haystack.includes("task")) return HammerIcon;
+
+  if (workEntry.activityKind === "turn.plan.updated") return ListTodoIcon;
+  if (workEntry.activityKind === "task.progress") return HammerIcon;
+  if (workEntry.activityKind === "approval.requested") return BotIcon;
+  if (workEntry.activityKind === "approval.resolved") return CheckIcon;
+  if (workEntry.itemType === "dynamic_tool_call") return WrenchIcon;
+  if (workEntry.itemType === "collab_agent_tool_call") return BotIcon;
+
+  return workEntry.tone === "info" ? CheckIcon : ZapIcon;
 }

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -14,14 +14,8 @@ import {
   BotIcon,
   CheckIcon,
   CircleAlertIcon,
-  EyeIcon,
-  GlobeIcon,
-  HammerIcon,
   type LucideIcon,
-  SquarePenIcon,
-  TerminalIcon,
   Undo2Icon,
-  WrenchIcon,
   ZapIcon,
 } from "lucide-react";
 import { Button } from "../ui/button";
@@ -32,7 +26,11 @@ import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesTree } from "./ChangedFilesTree";
 import { DiffStatLabel, hasNonZeroStat } from "./DiffStatLabel";
 import { MessageCopyButton } from "./MessageCopyButton";
-import { computeMessageDurationStart, normalizeCompactToolLabel } from "./MessagesTimeline.logic";
+import {
+  computeMessageDurationStart,
+  normalizeCompactToolLabel,
+  resolveWorkEntryIcon,
+} from "./MessagesTimeline.logic";
 import { cn } from "~/lib/utils";
 import { type TimestampFormat } from "../../appSettings";
 import { formatTimestamp } from "../../timestampFormat";
@@ -685,28 +683,7 @@ function workEntryPreview(
 }
 
 function workEntryIcon(workEntry: TimelineWorkEntry): LucideIcon {
-  if (workEntry.requestKind === "command") return TerminalIcon;
-  if (workEntry.requestKind === "file-read") return EyeIcon;
-  if (workEntry.requestKind === "file-change") return SquarePenIcon;
-
-  if (workEntry.itemType === "command_execution" || workEntry.command) {
-    return TerminalIcon;
-  }
-  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
-    return SquarePenIcon;
-  }
-  if (workEntry.itemType === "web_search") return GlobeIcon;
-  if (workEntry.itemType === "image_view") return EyeIcon;
-
-  switch (workEntry.itemType) {
-    case "mcp_tool_call":
-      return WrenchIcon;
-    case "dynamic_tool_call":
-    case "collab_agent_tool_call":
-      return HammerIcon;
-  }
-
-  return workToneIcon(workEntry.tone).icon;
+  return resolveWorkEntryIcon(workEntry);
 }
 
 function capitalizePhrase(value: string): string {


### PR DESCRIPTION
This PR fixes a bug where all tool activity icons were displaying as hammers because `dynamic_tool_call` and `collab_agent_tool_call` itemTypes had a hardcoded hammer fallback.

- Centralized icon resolution logic into `resolveWorkEntryIcon` in `apps/web/src/components/chat/MessagesTimeline.logic.ts`
- Changed `dynamic_tool_call` fallback from `HammerIcon` to `WrenchIcon` (generic tool icon)
- Changed `collab_agent_tool_call` fallback from `HammerIcon` to `BotIcon` (agent/assistant connotation)
- Kept `HammerIcon` specifically for `task.progress` activities where it makes semantic sense
- Updated both `ChatView.tsx` and `MessagesTimeline.tsx` to use the shared resolver
- Added focused test coverage for icon resolution in `MessagesTimeline.logic.test.ts`

<a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/pull/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/task/c6f19c7f-90da-45a8-9d0e-1d4c943e3d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-13&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-13"><img alt="TC-13 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=TC-13"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated icon selection logic in the chat messaging component, centralizing icon resolution into a reusable helper function to reduce code complexity.

* **Tests**
  * Added comprehensive test coverage for icon resolution functionality, validating icon selection across various work entry types and interaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->