### PR TITLE
Add new Copilot model aliases and catalog entries

### DIFF
--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -35,6 +35,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
   ],
   copilot: [
     { slug: "gpt-5.4", name: "GPT-5.4" },
+    { slug: "gpt-5.4-mini", name: "GPT-5.4 mini" },
     { slug: "claude-sonnet-4.6", name: "Claude Sonnet 4.6" },
     { slug: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
     { slug: "claude-haiku-4.5", name: "Claude Haiku 4.5" },
@@ -43,6 +44,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     { slug: "claude-opus-4.5", name: "Claude Opus 4.5" },
     { slug: "claude-sonnet-4", name: "Claude Sonnet 4" },
     { slug: "gemini-3-pro-preview", name: "Gemini 3 Pro (Preview)" },
+    { slug: "gemini-3.1-pro", name: "Gemini 3.1 Pro" },
     { slug: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
     { slug: "gpt-5.2-codex", name: "GPT-5.2 Codex" },
     { slug: "gpt-5.2", name: "GPT-5.2" },
@@ -52,6 +54,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     { slug: "gpt-5.1", name: "GPT-5.1" },
     { slug: "gpt-5-mini", name: "GPT-5 mini" },
     { slug: "gpt-4.1", name: "GPT-4.1" },
+    { slug: "raptor-mini", name: "Raptor mini" },
   ],
 } as const satisfies Record<ProviderKind, readonly ModelOption[]>;
 export type ModelOptionsByProvider = typeof MODEL_OPTIONS_BY_PROVIDER;
@@ -75,6 +78,7 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
   copilot: {
     "4.1": "gpt-4.1",
     "5.4": "gpt-5.4",
+    "5.4-mini": "gpt-5.4-mini",
     "5-mini": "gpt-5-mini",
     "5.1": "gpt-5.1",
     "5.1-codex": "gpt-5.1-codex",
@@ -87,6 +91,8 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
     sonnet: "claude-sonnet-4.6",
     opus: "claude-opus-4.6",
     gemini: "gemini-3-pro-preview",
+    "gemini-3.1": "gemini-3.1-pro",
+    raptor: "raptor-mini",
   },
 } as const satisfies Record<ProviderKind, Record<string, ModelSlug>>;
 

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -16,6 +16,12 @@ describe("normalizeModelSlug", () => {
     expect(normalizeModelSlug("gpt-5.3")).toBe("gpt-5.3-codex");
   });
 
+  it("maps copilot aliases to canonical slugs", () => {
+    expect(normalizeModelSlug("5.4-mini", "copilot")).toBe("gpt-5.4-mini");
+    expect(normalizeModelSlug("gemini-3.1", "copilot")).toBe("gemini-3.1-pro");
+    expect(normalizeModelSlug("raptor", "copilot")).toBe("raptor-mini");
+  });
+
   it("returns null for empty or missing values", () => {
     expect(normalizeModelSlug("")).toBeNull();
     expect(normalizeModelSlug("   ")).toBeNull();
@@ -50,6 +56,13 @@ describe("resolveModelSlug", () => {
       expect(resolveModelSlug(model.slug)).toBe(model.slug);
     }
   });
+
+  it("resolves supported copilot model options", () => {
+    for (const model of MODEL_OPTIONS_BY_PROVIDER.copilot) {
+      expect(resolveModelSlug(model.slug, "copilot")).toBe(model.slug);
+    }
+  });
+
   it("keeps codex defaults for backward compatibility", () => {
     expect(getDefaultModel()).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
     expect(getModelOptions()).toEqual(MODEL_OPTIONS_BY_PROVIDER.codex);


### PR DESCRIPTION
This pull request adds support for new copilot model options and their aliases, ensuring they are properly normalized and resolved. The main updates are to the `MODEL_OPTIONS_BY_PROVIDER` and `MODEL_SLUG_ALIASES_BY_PROVIDER` mappings, as well as corresponding tests for normalization and resolution.

New model options and aliases:

* Added `gpt-5.4-mini`, `gemini-3.1-pro`, and `raptor-mini` to the `copilot` provider in `MODEL_OPTIONS_BY_PROVIDER`, expanding available model choices. [[1]](diffhunk://#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959R38) [[2]](diffhunk://#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959R47) [[3]](diffhunk://#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959R57)
* Introduced new aliases (`5.4-mini`, `gemini-3.1`, `raptor`) for these models in `MODEL_SLUG_ALIASES_BY_PROVIDER` to improve user input flexibility. [[1]](diffhunk://#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959R81) [[2]](diffhunk://#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959R94-R95)

Testing enhancements:

* Added tests to verify that copilot aliases are correctly mapped to their canonical slugs and that all copilot model options resolve as expected. [[1]](diffhunk://#diff-698991b568d5a708e88e5354a2d43bf1cd0afbf0bfcabbc07378d2f6847537f0R19-R24) [[2]](diffhunk://#diff-698991b568d5a708e88e5354a2d43bf1cd0afbf0bfcabbc07378d2f6847537f0R59-R65)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new AI model options: GPT-5.4 mini, Gemini 3.1 Pro, and Raptor mini.
  * Introduced convenient shorthand aliases (5.4-mini, gemini-3.1, raptor) for streamlined model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->