### PR TITLE
security: add HTTP security headers, CSP, message size limit, remove core dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ apps/web/playwright-report
 apps/web/src/components/__screenshots__
 .vitest-*
 __screenshots__/
+core.*

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -416,6 +416,12 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     } satisfies OrchestrationCommand;
   });
 
+  /** Standard security headers applied to every HTTP response. */
+  const SECURITY_HEADERS: Record<string, string> = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+  };
+
   // HTTP server — serves static files or redirects to Vite dev server
   const httpServer = http.createServer((req, res) => {
     const respond = (
@@ -423,7 +429,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
       headers: Record<string, string>,
       body?: string | Uint8Array,
     ) => {
-      res.writeHead(statusCode, headers);
+      res.writeHead(statusCode, { ...SECURITY_HEADERS, ...headers });
       res.end(body);
     };
 
@@ -472,6 +478,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
           const contentType = Mime.getType(filePath) ?? "application/octet-stream";
           res.writeHead(200, {
+            ...SECURITY_HEADERS,
             "Content-Type": contentType,
             "Cache-Control": "public, max-age=31536000, immutable",
           });
@@ -960,10 +967,10 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
       );
 
     const messageText = websocketRawToString(raw);
-    if (messageText === null) {
+    if (messageText === null || messageText.length > 10 * 1024 * 1024) {
       return yield* sendWsResponse({
         id: "unknown",
-        error: { message: "Invalid request format: Failed to read message" },
+        error: { message: messageText === null ? "Invalid request format: Failed to read message" : "Message too large" },
       });
     }
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' ws: wss: http://localhost:* http://127.0.0.1:* https://fonts.googleapis.com https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self';"
+    />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Security Hardening

This PR addresses several findings from a security audit:

### Changes

1. **HTTP Security Headers** (`apps/server/src/wsServer.ts`)
   - Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to all HTTP responses
   - Prevents MIME-type sniffing attacks and clickjacking

2. **Content Security Policy** (`apps/web/index.html`)
   - Added CSP meta tag restricting script sources, connection targets, and frame ancestors
   - Uses `wasm-unsafe-eval` for Shiki syntax highlighting compatibility
   - Allows font loading from Google Fonts and WebSocket connections to localhost

3. **WebSocket Message Size Limit** (`apps/server/src/wsServer.ts`)
   - Added 10MB limit on incoming WebSocket messages
   - Prevents denial-of-service via oversized payloads

4. **Removed Core Dump** (`core.394`)
   - Removed accidentally committed 32MB ELF core dump file
   - Core dumps can contain sensitive data (env vars, tokens, memory contents)
   - Added `core.*` pattern to `.gitignore` to prevent future accidental commits

### Additional audit findings (not addressed in this PR)

- **MEDIUM**: No per-client rate limiting on WebSocket operations
- **MEDIUM**: Detailed error messages may leak filesystem paths to clients
- **MEDIUM**: Logger doesn't redact sensitive fields (tokens, passwords)
- **LOW**: Auth token passed as URL query parameter (logged in some environments)
- **LOW**: No maximum process timeout enforcement cap

These could be addressed in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Added server security headers for enhanced protection against common vulnerabilities
  * Implemented WebSocket message size validation with 10 MiB limit and improved error messages
  * Added Content Security Policy restricting resource loading origins and inline script execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->