### PR TITLE
fix: decode persisted Copilot provider in directory

### DIFF
--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
@@ -204,4 +204,71 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
 
       fs.rmSync(tempDir, { recursive: true, force: true });
     }));
+
+  it("rehydrates persisted copilot runtime rows", () =>
+    Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = ThreadId.make("thread-copilot");
+
+      yield* runtimeRepository.upsert({
+        threadId,
+        providerName: "copilot",
+        adapterKey: "copilot",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: new Date().toISOString(),
+        resumeCursor: {
+          threadId: "copilot-thread",
+        },
+        runtimePayload: {
+          model: "gpt-5.4-mini",
+        },
+      });
+
+      const provider = yield* directory.getProvider(threadId);
+      assert.equal(provider, "copilot");
+
+      const binding = yield* directory.getBinding(threadId);
+      assertSome(binding, {
+        threadId,
+        provider: "copilot",
+        adapterKey: "copilot",
+        runtimeMode: "full-access",
+        status: "running",
+        resumeCursor: {
+          threadId: "copilot-thread",
+        },
+        runtimePayload: {
+          model: "gpt-5.4-mini",
+        },
+      });
+    }));
+
+  it("fails on unknown persisted providers", () =>
+    Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = ThreadId.make("thread-unknown-provider");
+
+      yield* runtimeRepository.upsert({
+        threadId,
+        providerName: "unknown-provider",
+        adapterKey: "unknown-provider",
+        runtimeMode: "full-access",
+        status: "running",
+        lastSeenAt: new Date().toISOString(),
+        resumeCursor: null,
+        runtimePayload: null,
+      });
+
+      const provider = yield* directory.getProvider(threadId).pipe(Effect.result);
+      assertFailure(
+        provider,
+        new ProviderSessionDirectoryPersistenceError({
+          operation: "ProviderSessionDirectory.getBinding",
+          detail: "Unknown persisted provider 'unknown-provider'.",
+        }),
+      );
+    }));
 });

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -1,5 +1,5 @@
-import { type ProviderKind, type ThreadId } from "@t3tools/contracts";
-import { Effect, Layer, Option } from "effect";
+import { ProviderKind, type ThreadId } from "@t3tools/contracts";
+import { Effect, Layer, Option, Schema } from "effect";
 
 import { ProviderSessionRuntimeRepository } from "../../persistence/Services/ProviderSessionRuntime.ts";
 import { ProviderSessionDirectoryPersistenceError, ProviderValidationError } from "../Errors.ts";
@@ -22,7 +22,7 @@ function decodeProviderKind(
   providerName: string,
   operation: string,
 ): Effect.Effect<ProviderKind, ProviderSessionDirectoryPersistenceError> {
-  if (providerName === "codex" || providerName === "claudeAgent") {
+  if (Schema.is(ProviderKind)(providerName)) {
     return Effect.succeed(providerName);
   }
   return Effect.fail(

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -746,6 +746,59 @@ describe("incremental orchestration updates", () => {
     expect(threadsOf(next)[0]?.messages).toHaveLength(1);
   });
 
+  it("preserves copilot provider when thread.session-set arrives", () => {
+    const thread = makeThread({
+      modelSelection: {
+        provider: "copilot",
+        model: DEFAULT_MODEL_BY_PROVIDER.copilot,
+      },
+    });
+    const state = makeState(thread);
+
+    const next = applyOrchestrationEvent(
+      state,
+      makeEvent("thread.session-set", {
+        threadId: thread.id,
+        session: {
+          threadId: thread.id,
+          status: "running",
+          providerName: "copilot",
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("turn-1"),
+          lastError: null,
+          updatedAt: "2026-02-27T00:00:02.000Z",
+        },
+      }),
+      localEnvironmentId,
+    );
+
+    expect(threadsOf(next)[0]?.session?.provider).toBe("copilot");
+  });
+
+  it("falls back to codex for invalid session providers", () => {
+    const thread = makeThread();
+    const state = makeState(thread);
+
+    const next = applyOrchestrationEvent(
+      state,
+      makeEvent("thread.session-set", {
+        threadId: thread.id,
+        session: {
+          threadId: thread.id,
+          status: "running",
+          providerName: "invalid-provider" as never,
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("turn-1"),
+          lastError: null,
+          updatedAt: "2026-02-27T00:00:02.000Z",
+        },
+      }),
+      localEnvironmentId,
+    );
+
+    expect(threadsOf(next)[0]?.session?.provider).toBe("codex");
+  });
+
   it("does not regress latestTurn when an older turn diff completes late", () => {
     const state = makeState(
       makeThread({

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -15,12 +15,13 @@ import type {
   OrchestrationThreadShell,
   OrchestrationThreadActivity,
   ProjectId,
-  ProviderKind,
   ScopedProjectRef,
   ScopedThreadRef,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import { ProviderKind } from "@t3tools/contracts";
+import { Schema } from "effect";
 import { resolveModelSlugForProvider } from "@t3tools/shared/model";
 import { create } from "zustand";
 import {
@@ -1001,7 +1002,7 @@ function toLegacySessionStatus(
 }
 
 function toLegacyProvider(providerName: string | null): ProviderKind {
-  if (providerName === "codex" || providerName === "claudeAgent") {
+  if (Schema.is(ProviderKind)(providerName)) {
     return providerName;
   }
   return "codex";


### PR DESCRIPTION
## What Changed

- Replaced hand-maintained provider allowlists with `Schema.is(ProviderKind)` in `ProviderSessionDirectory.decodeProviderKind()` to correctly decode persisted `copilot` rows
- Fixed web store `toLegacyProvider()` to preserve `copilot` sessions instead of falling back to `codex`
- Added regression tests for Copilot rehydration and unknown provider failure

## Why

Persisted `copilot` sessions were failing to resume with `ProviderSessionDirectoryPersistenceError: Unknown persisted provider 'copilot'`. Web sessions with `copilot` were incorrectly mapped to `codex` on session update, causing UI provider labels to flip between selections. Using the shared `ProviderKind` schema contract ensures all three valid providers (`codex`, `copilot`, `claudeAgent`) are accepted without introducing additional brittle allowlists.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/thread/2da504de-59cd-40f4-b5f4-23e799764669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open TC-013" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/thread/2da504de-59cd-40f4-b5f4-23e799764669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=TC-013&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=TC-013"><img alt="TC-013" src="https://capy.ai/api/badge/thread.svg?label=TC-013"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive tests for provider session handling and validation, including copilot runtime rehydration and error cases.
  * Added tests for session provider updates and fallback behavior.

* **Bug Fixes**
  * Improved provider validation to use robust runtime schema checking instead of basic string matching.
  * Enhanced error handling for unrecognized providers with clearer error reporting.
  * Added fallback to default provider when invalid provider names are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->