### PR TITLE
Upgrade Copilot SDK to v0.2.2

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,7 +27,7 @@
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
-    "@github/copilot-sdk": "^0.2.1",
+    "@github/copilot-sdk": "^0.2.2",
     "@pierre/diffs": "^1.1.0-beta.16",
     "effect": "catalog:",
     "node-pty": "^1.1.0",

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
         "@effect/platform-bun": "catalog:",
         "@effect/platform-node": "catalog:",
         "@effect/sql-sqlite-bun": "catalog:",
-        "@github/copilot-sdk": "^0.2.1",
+        "@github/copilot-sdk": "^0.2.2",
         "@pierre/diffs": "^1.1.0-beta.16",
         "effect": "catalog:",
         "node-pty": "^1.1.0",


### PR DESCRIPTION
Bumps the GitHub Copilot SDK dependency to the latest stable release.

- Updated `@github/copilot-sdk` from `^0.2.1` to `^0.2.2` in `apps/server/package.json`
- Refreshed `bun.lock` with the new dependency resolution

The upgrade required no code changes—existing integration (`CopilotClient`, `listModels()`, session `send()`/`getMessages()`, CLI path resolution) remains compatible with 0.2.2's API surface. All Copilot provider tests and type checks pass.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/thread/9c6781b2-a87c-46aa-b136-a58d7e050a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open TC-016" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/f3682762-89d7-4e10-9ed9-45da9497f187/thread/9c6781b2-a87c-46aa-b136-a58d7e050a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=TC-016&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=TC-016"><img alt="TC-016" src="https://capy.ai/api/badge/thread.svg?label=TC-016"></picture></a>
<!-- capy-pr-badge:end -->